### PR TITLE
feat: 위원회용 로그인 페이지 ui 구현

### DIFF
--- a/src/app/committee/page.tsx
+++ b/src/app/committee/page.tsx
@@ -1,0 +1,5 @@
+import CommitteeMain from "@/components/page/committee/Main";
+
+export default function CommitteeMainPage() {
+  return <CommitteeMain />;
+}

--- a/src/components/page/committee/Main/Form/index.module.scss
+++ b/src/components/page/committee/Main/Form/index.module.scss
@@ -1,0 +1,28 @@
+.form {
+  @include flexSort(column, null, center, 2rem);
+  width: 40rem;
+}
+
+.title {
+  font-size: 5rem;
+  padding-bottom: 2rem;
+  width: 100%;
+  text-align: center;
+}
+
+.inputContainer {
+  @include flexSort(column, center, center, 2rem);
+  width: 100%;
+}
+
+.certificationBtn,
+.emailBtn {
+  width: 7rem;
+  height: 5rem;
+}
+
+.completeBtn {
+  margin-top: 2rem;
+  width: 100%;
+  height: 5rem;
+}

--- a/src/components/page/committee/Main/Form/index.tsx
+++ b/src/components/page/committee/Main/Form/index.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Button from "@/components/design-system/Button";
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import Txt from "@/components/design-system/Txt";
+import TextInput from "@/components/common/TextInput";
+import useCommitteeSignInForm from "@/hooks/committee/sign-in/useCommitteeSignInForm";
+
+const cn = classNames.bind(styles);
+
+export default function CommitteeSignInForm() {
+  const { formAction, formData, error, onInputChange } = useCommitteeSignInForm();
+
+  return (
+    <form onSubmit={formAction} className={cn("form")}>
+      <Txt weight="semiBold" className={cn("title")}>
+        로그인
+      </Txt>
+      <div className={cn("inputContainer")}>
+        <TextInput
+          id="email"
+          type="email"
+          label="이메일"
+          placeholder="이메일을 입력해주세요."
+          value={formData.email}
+          onChange={onInputChange}
+        />
+        <TextInput
+          id="password"
+          type="password"
+          label="비밀번호"
+          placeholder="비밀번호를 입력해주세요."
+          value={formData.password}
+          onChange={onInputChange}
+        />
+      </div>
+      {error.isError && (
+        <Txt size="tiny" color="error">
+          {error.errorMessage}
+        </Txt>
+      )}
+      <Button type="submit" className={cn("completeBtn")}>
+        <Txt size="h5" color="white" weight="medium">
+          로그인
+        </Txt>
+      </Button>
+    </form>
+  );
+}

--- a/src/components/page/committee/Main/index.module.scss
+++ b/src/components/page/committee/Main/index.module.scss
@@ -1,0 +1,5 @@
+.container {
+  @include flexSort(row, center, center, null);
+  flex: 1;
+  padding: 10rem 0;
+}

--- a/src/components/page/committee/Main/index.tsx
+++ b/src/components/page/committee/Main/index.tsx
@@ -1,0 +1,16 @@
+import AuthorizationLayout from "@/components/Layout/committee/AuthorizationLayout";
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import CommitteeSignInForm from "@/components/page/committee/Main/Form";
+
+const cn = classNames.bind(styles);
+
+export default function CommitteeMain() {
+  return (
+    <AuthorizationLayout>
+      <div className={cn("container")}>
+        <CommitteeSignInForm />
+      </div>
+    </AuthorizationLayout>
+  );
+}

--- a/src/constants/error/index.ts
+++ b/src/constants/error/index.ts
@@ -84,6 +84,16 @@ export const APPLY_LOCKER = {
   },
 };
 
+export const COMMITTEE_SIGN_IN = {
+  email: {
+    [VALIDATION_TYPES.REQUIRED]: "이메일을 입력해 주세요.",
+  },
+  password: {
+    [VALIDATION_TYPES.REQUIRED]: "비밀번호를 입력해 주세요.",
+    [VALIDATION_TYPES.FORMAT]: "비밀번호는 최소 9자 이상이며 최소 하나의 영문자, 숫자, 특수문자가 포함되어야 합니다.",
+  },
+};
+
 export const COMMITTEE_SIGN_UP = {
   category: {
     [VALIDATION_TYPES.REQUIRED]: "유형을 입력해 주세요.",

--- a/src/hooks/committee/sign-in/useCommitteeSignInForm.ts
+++ b/src/hooks/committee/sign-in/useCommitteeSignInForm.ts
@@ -1,0 +1,48 @@
+import { FormEvent } from "react";
+import { COMMITTEE_SIGN_IN, VALIDATION_TYPES } from "@/constants/error";
+import { isPassword } from "@/utils/validator";
+import { useFormError } from "@/hooks/common/useFormError";
+import { useCommitteeSignInFormData } from "@/hooks/committee/sign-in/useCommitteeSignInFormData";
+
+const useCommitteeSignInForm = () => {
+  const { formData, onInputChange } = useCommitteeSignInFormData();
+
+  const { error, setFormError, clearError } = useFormError();
+
+  const validateForm = () => {
+    const fields = Object.keys(COMMITTEE_SIGN_IN) as Array<keyof typeof COMMITTEE_SIGN_IN>;
+
+    for (const field of fields) {
+      if (!formData[field]) {
+        return COMMITTEE_SIGN_IN[field][VALIDATION_TYPES.REQUIRED];
+      }
+    }
+
+    if (!isPassword(formData.password)) {
+      return COMMITTEE_SIGN_IN.password[VALIDATION_TYPES.FORMAT];
+    }
+
+    return null;
+  };
+
+  const formAction = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    clearError();
+
+    const errorMessage = validateForm();
+    if (errorMessage) {
+      setFormError(errorMessage);
+      alert(errorMessage);
+      return;
+    }
+  };
+
+  return {
+    formAction,
+    formData,
+    error,
+    onInputChange,
+  };
+};
+
+export default useCommitteeSignInForm;

--- a/src/hooks/committee/sign-in/useCommitteeSignInFormData.ts
+++ b/src/hooks/committee/sign-in/useCommitteeSignInFormData.ts
@@ -1,0 +1,28 @@
+import { ChangeEvent, useState } from "react";
+
+export interface CommitteeFormData {
+  email: string;
+  password: string;
+}
+
+export const useCommitteeSignInFormData = () => {
+  const [formData, setFormData] = useState<CommitteeFormData>({
+    email: "",
+    password: "",
+  });
+
+  const onInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { id, value } = e.target;
+
+    setFormData((prev) => ({
+      ...prev,
+      [id]: value,
+    }));
+  };
+
+  return {
+    formData,
+    setFormData,
+    onInputChange,
+  };
+};


### PR DESCRIPTION
### 개요

close #25 

### 작업사항

- 위원회용 로그인 페이지 ui 구현

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 위원회 전용 페이지와 메인 인터페이스를 추가하여 사용자가 위원회 로그인 과정을 진행할 수 있게 되었습니다.
	- 이메일 및 비밀번호 입력을 처리하는 로그인 폼 컴포넌트가 도입되었고, 오류 및 검증 메시지를 통해 사용자 입력을 개선했습니다.
	- 인터페이스의 시각적 일관성을 위해 새로운 스타일과 레이아웃이 적용되었습니다.
	- 폼 상태 관리와 입력 검증을 위한 커스텀 훅이 추가되어 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->