### PR TITLE
feat: 학생용 회원가입 페이지에 메일 인증 로직 추가

### DIFF
--- a/src/apis/common/sign-up/index.ts
+++ b/src/apis/common/sign-up/index.ts
@@ -1,6 +1,6 @@
 import { Department, Organization } from "@/apis/dtos/sign-up";
 import { https } from "@/apis/https";
-import { SubmitEmailData } from "@/types/common/sign-up";
+import { SubmitCertificationCodeData, SubmitEmailData } from "@/types/common/sign-up";
 
 export const getOrganizations = async (type: "COUNCIL" | "COMMITTEE") => {
   const { data } = await https.get(`organizations?type=${type}`);
@@ -20,4 +20,8 @@ export const getDepartments = async (id: number) => {
 
 export const postSubmitEmail = async (data: SubmitEmailData) => {
   await https.post("auth/send-email", data);
+};
+
+export const postVerifyCertificationCode = async (data: SubmitCertificationCodeData) => {
+  await https.post("auth/verify", data);
 };

--- a/src/apis/common/sign-up/index.ts
+++ b/src/apis/common/sign-up/index.ts
@@ -1,5 +1,6 @@
 import { Department, Organization } from "@/apis/dtos/sign-up";
 import { https } from "@/apis/https";
+import { SubmitEmailData } from "@/types/common/sign-up";
 
 export const getOrganizations = async (type: "COUNCIL" | "COMMITTEE") => {
   const { data } = await https.get(`organizations?type=${type}`);
@@ -15,4 +16,8 @@ export const getDepartments = async (id: number) => {
   const departments = data.map(({ id, name }: { id: number; name: string }) => new Department({ id, name }));
 
   return departments;
+};
+
+export const postSubmitEmail = async (data: SubmitEmailData) => {
+  await https.post("auth/send-email", data);
 };

--- a/src/components/page/student/SignUp/Form/index.tsx
+++ b/src/components/page/student/SignUp/Form/index.tsx
@@ -106,21 +106,6 @@ export default function SignUpForm() {
           </Button>
         </TextInput>
         <TextInput
-          containerClassName={cn("certificationContainer")}
-          id="phoneNumberCertificationNumber"
-          type="text"
-          label="연락처 인증코드"
-          placeholder="연락처 인증코드를 입력해주세요."
-          value={formData.phoneNumberCertificationNumber}
-          onChange={onInputChange}
-        >
-          <Button type="button" className={cn("certificationBtn")}>
-            <Txt size="tiny" weight="bold" color="white">
-              인증하기
-            </Txt>
-          </Button>
-        </TextInput>
-        <TextInput
           id="name"
           type="text"
           label="이름"

--- a/src/components/page/student/SignUp/Form/index.tsx
+++ b/src/components/page/student/SignUp/Form/index.tsx
@@ -11,8 +11,18 @@ import { Selector } from "@/components/common/Selector";
 const cn = classNames.bind(styles);
 
 export default function SignUpForm() {
-  const { formAction, formData, error, departments, onInputChange, onSelectChange, organizations } =
-    useStudentSignUpForm();
+  const {
+    formAction,
+    formData,
+    error,
+    departments,
+    onInputChange,
+    onSelectChange,
+    organizations,
+    isEmailCertification,
+    onSubmitEmail,
+    countdown,
+  } = useStudentSignUpForm();
 
   return (
     <form onSubmit={formAction} className={cn("form")}>
@@ -39,28 +49,37 @@ export default function SignUpForm() {
           placeholder="이메일을 입력해주세요."
           value={formData.email}
           onChange={onInputChange}
+          disabled={countdown ? countdown > 0 : false}
         >
-          <Button type="button" className={cn("emailBtn")}>
+          <Button
+            disabled={countdown ? countdown > 0 : false}
+            type="button"
+            className={cn("emailBtn")}
+            onClick={() => onSubmitEmail({ email: formData.email })}
+          >
             <Txt size="tiny" weight="bold" color="white">
               메일전송
             </Txt>
           </Button>
         </TextInput>
-        <TextInput
-          containerClassName={cn("certificationContainer")}
-          id="emailCertificationNumber"
-          type="text"
-          label="이메일 인증코드"
-          placeholder="이메일 인증코드를 입력해주세요."
-          value={formData.emailCertificationNumber}
-          onChange={onInputChange}
-        >
-          <Button type="button" className={cn("certificationBtn")}>
-            <Txt size="tiny" weight="bold" color="white">
-              인증하기
-            </Txt>
-          </Button>
-        </TextInput>
+        {countdown && <Txt size="tiny">인증 코드 유효 시간 : {countdown}초</Txt>}
+        {isEmailCertification && (
+          <TextInput
+            containerClassName={cn("certificationContainer")}
+            id="emailCertificationNumber"
+            type="text"
+            label="이메일 인증코드"
+            placeholder="이메일 인증코드를 입력해주세요."
+            value={formData.emailCertificationNumber}
+            onChange={onInputChange}
+          >
+            <Button type="button" className={cn("certificationBtn")}>
+              <Txt size="tiny" weight="bold" color="white">
+                인증하기
+              </Txt>
+            </Button>
+          </TextInput>
+        )}
         <TextInput
           containerClassName={cn("phoneNumberInputContainer")}
           id="phoneNumber"

--- a/src/components/page/student/SignUp/Form/index.tsx
+++ b/src/components/page/student/SignUp/Form/index.tsx
@@ -43,6 +43,14 @@ export default function SignUpForm() {
           id="department"
         />
         <TextInput
+          id="studentNumber"
+          type="text"
+          label="학번"
+          placeholder="학번을 입력해주세요."
+          value={formData.studentNumber}
+          onChange={onInputChange}
+        />
+        <TextInput
           containerClassName={cn("emailInputContainer")}
           id="email"
           type="email"
@@ -98,13 +106,7 @@ export default function SignUpForm() {
           placeholder="연락처를 입력해주세요."
           value={formData.phoneNumber}
           onChange={onInputChange}
-        >
-          <Button type="button" className={cn("certificationBtn")}>
-            <Txt size="tiny" weight="bold" color="white">
-              전송
-            </Txt>
-          </Button>
-        </TextInput>
+        />
         <TextInput
           id="name"
           type="text"

--- a/src/components/page/student/SignUp/Form/index.tsx
+++ b/src/components/page/student/SignUp/Form/index.tsx
@@ -22,6 +22,7 @@ export default function SignUpForm() {
     isEmailCertification,
     onSubmitEmail,
     countdown,
+    onVerifyCertificationCode,
   } = useStudentSignUpForm();
 
   return (
@@ -73,7 +74,16 @@ export default function SignUpForm() {
             value={formData.emailCertificationNumber}
             onChange={onInputChange}
           >
-            <Button type="button" className={cn("certificationBtn")}>
+            <Button
+              type="button"
+              className={cn("certificationBtn")}
+              onClick={() =>
+                onVerifyCertificationCode({
+                  email: formData.email,
+                  code: formData.emailCertificationNumber,
+                })
+              }
+            >
               <Txt size="tiny" weight="bold" color="white">
                 인증하기
               </Txt>

--- a/src/constants/error/index.ts
+++ b/src/constants/error/index.ts
@@ -18,9 +18,6 @@ export const STUDENT_SIGN_UP = {
   phoneNumber: {
     [VALIDATION_TYPES.REQUIRED]: "연락처를 입력해 주세요.",
   },
-  phoneNumberCertificationNumber: {
-    [VALIDATION_TYPES.REQUIRED]: "연락처 인증코드를 입력해 주세요.",
-  },
   name: {
     [VALIDATION_TYPES.REQUIRED]: "이름을 입력해 주세요.",
   },

--- a/src/constants/error/index.ts
+++ b/src/constants/error/index.ts
@@ -12,6 +12,9 @@ export const STUDENT_SIGN_UP = {
     [VALIDATION_TYPES.REQUIRED]: "이메일을 입력해 주세요.",
     [VALIDATION_TYPES.FORMAT]: "올바른 형식(@jnu.ac.kr로 끝나는)의 이메일을 입력해 주세요.",
   },
+  studentNumber: {
+    [VALIDATION_TYPES.REQUIRED]: "학번을 입력해 주세요.",
+  },
   emailCertificationNumber: {
     [VALIDATION_TYPES.REQUIRED]: "이메일 인증코드를 입력해 주세요.",
   },

--- a/src/functions/date.ts
+++ b/src/functions/date.ts
@@ -1,0 +1,3 @@
+export const convertToKST = (dateString: Date): string => {
+  return new Date(new Date(dateString).getTime() + 9 * 60 * 60 * 1000).toISOString().replace(".000Z", "");
+};

--- a/src/hooks/common/useTimer.ts
+++ b/src/hooks/common/useTimer.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+export const useTimer = () => {
+  const [countdown, setCountdown] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (countdown === null) return;
+
+    const timer = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev === null || prev <= 1) {
+          clearInterval(timer);
+          return null;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [countdown]);
+
+  return {
+    countdown,
+    setCountdown,
+  };
+};

--- a/src/hooks/student/sign-up/useEmailCertification.ts
+++ b/src/hooks/student/sign-up/useEmailCertification.ts
@@ -1,0 +1,10 @@
+import { useState } from "react";
+
+export const useEmailCertification = () => {
+  const [isEmailCertification, setIsEmailCertification] = useState(false);
+
+  return {
+    isEmailCertification,
+    setIsEmailCertification,
+  };
+};

--- a/src/hooks/student/sign-up/useStudentFormData.ts
+++ b/src/hooks/student/sign-up/useStudentFormData.ts
@@ -14,7 +14,6 @@ export interface StudentFormData {
   email: string;
   emailCertificationNumber: string;
   phoneNumber: string;
-  phoneNumberCertificationNumber: string;
   password: string;
   passwordConfirm: string;
 }
@@ -33,7 +32,6 @@ export const useStudentFormData = () => {
     email: "",
     emailCertificationNumber: "",
     phoneNumber: "",
-    phoneNumberCertificationNumber: "",
     password: "",
     passwordConfirm: "",
   });

--- a/src/hooks/student/sign-up/useStudentFormData.ts
+++ b/src/hooks/student/sign-up/useStudentFormData.ts
@@ -16,6 +16,7 @@ export interface StudentFormData {
   phoneNumber: string;
   password: string;
   passwordConfirm: string;
+  studentNumber: string;
 }
 
 export const useStudentFormData = () => {
@@ -34,6 +35,7 @@ export const useStudentFormData = () => {
     phoneNumber: "",
     password: "",
     passwordConfirm: "",
+    studentNumber: "",
   });
 
   const onSelectChange = (e: ChangeEvent<HTMLSelectElement>) => {

--- a/src/hooks/student/sign-up/useStudentSignUp.ts
+++ b/src/hooks/student/sign-up/useStudentSignUp.ts
@@ -1,7 +1,12 @@
 import { FormEvent } from "react";
 import { isEmail, isPassword } from "@/utils/validator";
 import { STUDENT_SIGN_UP, VALIDATION_TYPES } from "@/constants/error";
-import { useDepartmentsQuery, useOrganizationsQuery, useSubmitEmail } from "@/hooks/tanstack-query/common/sign-up";
+import {
+  useDepartmentsQuery,
+  useOrganizationsQuery,
+  useSubmitEmail,
+  useVerifyCertificationCode,
+} from "@/hooks/tanstack-query/common/sign-up";
 import { useStudentSignUp } from "@/hooks/tanstack-query/student/sign-up";
 import { useStudentFormData } from "@/hooks/student/sign-up/useStudentFormData";
 import { useFormError } from "@/hooks/common/useFormError";
@@ -20,6 +25,8 @@ const useStudentSignUpForm = () => {
   const { onSubmitEmail } = useSubmitEmail(setIsEmailCertification, setCountdown);
 
   const { error, setFormError, clearError } = useFormError();
+
+  const { onVerifyCertificationCode } = useVerifyCertificationCode(setCountdown);
 
   let organizations = useOrganizationsQuery("학생회");
 
@@ -106,6 +113,7 @@ const useStudentSignUpForm = () => {
     isEmailCertification,
     onSubmitEmail,
     countdown,
+    onVerifyCertificationCode,
   };
 };
 

--- a/src/hooks/student/sign-up/useStudentSignUp.ts
+++ b/src/hooks/student/sign-up/useStudentSignUp.ts
@@ -1,15 +1,23 @@
 import { FormEvent } from "react";
 import { isEmail, isPassword } from "@/utils/validator";
 import { STUDENT_SIGN_UP, VALIDATION_TYPES } from "@/constants/error";
-import { useDepartmentsQuery, useOrganizationsQuery } from "@/hooks/tanstack-query/common/sign-up";
+import { useDepartmentsQuery, useOrganizationsQuery, useSubmitEmail } from "@/hooks/tanstack-query/common/sign-up";
 import { useStudentSignUp } from "@/hooks/tanstack-query/student/sign-up";
 import { useStudentFormData } from "@/hooks/student/sign-up/useStudentFormData";
 import { useFormError } from "@/hooks/common/useFormError";
+import { useEmailCertification } from "@/hooks/student/sign-up/useEmailCertification";
+import { useTimer } from "@/hooks/common/useTimer";
 
 const useStudentSignUpForm = () => {
   const { onStudentSignUp } = useStudentSignUp();
 
   const { formData, onSelectChange, onInputChange } = useStudentFormData();
+
+  const { isEmailCertification, setIsEmailCertification } = useEmailCertification();
+
+  const { countdown, setCountdown } = useTimer();
+
+  const { onSubmitEmail } = useSubmitEmail(setIsEmailCertification, setCountdown);
 
   const { error, setFormError, clearError } = useFormError();
 
@@ -95,6 +103,9 @@ const useStudentSignUpForm = () => {
     error,
     organizations,
     departments,
+    isEmailCertification,
+    onSubmitEmail,
+    countdown,
   };
 };
 

--- a/src/hooks/student/sign-up/useStudentSignUp.ts
+++ b/src/hooks/student/sign-up/useStudentSignUp.ts
@@ -59,9 +59,6 @@ const useStudentSignUpForm = () => {
       if (field === "phoneNumber" && !formData.phoneNumber) {
         return STUDENT_SIGN_UP[field][VALIDATION_TYPES.REQUIRED];
       }
-      if (field === "phoneNumberCertificationNumber" && !formData.phoneNumberCertificationNumber) {
-        return STUDENT_SIGN_UP[field][VALIDATION_TYPES.REQUIRED];
-      }
       if (field === "name" && !formData.name) {
         return STUDENT_SIGN_UP[field][VALIDATION_TYPES.REQUIRED];
       }

--- a/src/hooks/student/sign-up/useStudentSignUp.ts
+++ b/src/hooks/student/sign-up/useStudentSignUp.ts
@@ -96,6 +96,7 @@ const useStudentSignUpForm = () => {
       password: formData.password,
       departmentId: formData.department.id,
       phoneNumber: formData.phoneNumber,
+      studentNumber: formData.studentNumber,
     });
   };
 

--- a/src/hooks/tanstack-query/committee/event/index.tsx
+++ b/src/hooks/tanstack-query/committee/event/index.tsx
@@ -4,6 +4,7 @@ import { ROUTE } from "@/constants/routes";
 import { AxiosError } from "axios";
 import { postCreateEvent } from "@/apis/committee/event";
 import { CreateEventForm, CreateEventRequest } from "@/types/committee/event";
+import { convertToKST } from "@/functions/date";
 
 export const useCreateEvent = () => {
   const router = useRouter();
@@ -38,12 +39,8 @@ export const useCreateEvent = () => {
       return;
     }
 
-    const startAtKST = new Date(new Date(formData.startAt).getTime() + 9 * 60 * 60 * 1000)
-      .toISOString()
-      .replace(".000Z", "");
-    const endAtKST = new Date(new Date(formData.endAt).getTime() + 9 * 60 * 60 * 1000)
-      .toISOString()
-      .replace(".000Z", "");
+    const startAtKST = convertToKST(formData.startAt);
+    const endAtKST = convertToKST(formData.endAt);
 
     const requestData: CreateEventRequest = {
       title: formData.title,

--- a/src/hooks/tanstack-query/committee/event/index.tsx
+++ b/src/hooks/tanstack-query/committee/event/index.tsx
@@ -38,10 +38,17 @@ export const useCreateEvent = () => {
       return;
     }
 
+    const startAtKST = new Date(new Date(formData.startAt).getTime() + 9 * 60 * 60 * 1000)
+      .toISOString()
+      .replace(".000Z", "");
+    const endAtKST = new Date(new Date(formData.endAt).getTime() + 9 * 60 * 60 * 1000)
+      .toISOString()
+      .replace(".000Z", "");
+
     const requestData: CreateEventRequest = {
       title: formData.title,
-      startAt: formData.startAt as Date,
-      endAt: formData.endAt as Date,
+      startAt: startAtKST,
+      endAt: endAtKST,
       participationDepartmentIds: formData.participationDepartmentIds.map((department) => department.id),
       floors: formData.floors.map((floor) => ({
         floorNumber: floor.floorNumber as number,

--- a/src/hooks/tanstack-query/common/sign-up/index.ts
+++ b/src/hooks/tanstack-query/common/sign-up/index.ts
@@ -1,5 +1,9 @@
-import { getDepartments, getOrganizations } from "@/apis/common/sign-up";
+import { getDepartments, getOrganizations, postSubmitEmail } from "@/apis/common/sign-up";
+import { SubmitEmailData } from "@/types/common/sign-up";
 import { useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { Dispatch, SetStateAction } from "react";
 
 export const useOrganizationsQuery = (type: "학생회" | "위원회" | "값을 선택해주세요.") => {
   let category: "COUNCIL" | "COMMITTEE";
@@ -29,4 +33,35 @@ export const useDepartmentsQuery = (id: number) => {
   });
 
   return departments;
+};
+
+export const useSubmitEmail = (
+  setIsEmailCertification: Dispatch<SetStateAction<boolean>>,
+  setCountdown: Dispatch<SetStateAction<number | null>>,
+) => {
+  const { mutate } = useSubmitEmailMutate();
+
+  const onSubmitEmail = (data: SubmitEmailData) => {
+    mutate(data, {
+      onError: (error: AxiosError<{ message: string }>) => {
+        alert(error.response?.data.message || "이메일 전송에 실패했습니다.");
+      },
+      onSuccess: () => {
+        setIsEmailCertification(true);
+        setCountdown(300);
+        alert("해당 이메일로 인증코드가 전송되었습니다. 이메일을 확인해주세요.");
+      },
+    });
+  };
+
+  return {
+    onSubmitEmail,
+  };
+};
+
+export const useSubmitEmailMutate = () => {
+  return useMutation<void, AxiosError<{ message: string }>, SubmitEmailData>({
+    mutationKey: ["submitEmail"],
+    mutationFn: postSubmitEmail,
+  });
 };

--- a/src/hooks/tanstack-query/common/sign-up/index.ts
+++ b/src/hooks/tanstack-query/common/sign-up/index.ts
@@ -1,4 +1,4 @@
-import { getDepartments, getOrganizations, postSubmitEmail } from "@/apis/common/sign-up";
+import { getDepartments, getOrganizations, postSubmitEmail, postVerifyCertificationCode } from "@/apis/common/sign-up";
 import { SubmitCertificationCodeData, SubmitEmailData } from "@/types/common/sign-up";
 import { useQuery } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
@@ -89,6 +89,6 @@ export const useVerifyCertificationCode = (setCountdown: Dispatch<SetStateAction
 export const useVerifyCertificationCodeMutate = () => {
   return useMutation<void, AxiosError<{ message: string }>, SubmitCertificationCodeData>({
     mutationKey: ["verifyCertificationCode"],
-    mutationFn: postSubmitEmail,
+    mutationFn: postVerifyCertificationCode,
   });
 };

--- a/src/hooks/tanstack-query/common/sign-up/index.ts
+++ b/src/hooks/tanstack-query/common/sign-up/index.ts
@@ -1,5 +1,5 @@
 import { getDepartments, getOrganizations, postSubmitEmail } from "@/apis/common/sign-up";
-import { SubmitEmailData } from "@/types/common/sign-up";
+import { SubmitCertificationCodeData, SubmitEmailData } from "@/types/common/sign-up";
 import { useQuery } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
 import { AxiosError } from "axios";
@@ -62,6 +62,33 @@ export const useSubmitEmail = (
 export const useSubmitEmailMutate = () => {
   return useMutation<void, AxiosError<{ message: string }>, SubmitEmailData>({
     mutationKey: ["submitEmail"],
+    mutationFn: postSubmitEmail,
+  });
+};
+
+export const useVerifyCertificationCode = (setCountdown: Dispatch<SetStateAction<number | null>>) => {
+  const { mutate } = useVerifyCertificationCodeMutate();
+
+  const onVerifyCertificationCode = (data: SubmitCertificationCodeData) => {
+    mutate(data, {
+      onError: (error: AxiosError<{ message: string }>) => {
+        alert(error.response?.data.message || "인증에 실패하였습니다.");
+      },
+      onSuccess: () => {
+        setCountdown(null);
+        alert("인증에 성공하였습니다.");
+      },
+    });
+  };
+
+  return {
+    onVerifyCertificationCode,
+  };
+};
+
+export const useVerifyCertificationCodeMutate = () => {
+  return useMutation<void, AxiosError<{ message: string }>, SubmitCertificationCodeData>({
+    mutationKey: ["verifyCertificationCode"],
     mutationFn: postSubmitEmail,
   });
 };

--- a/src/types/committee/event/index.ts
+++ b/src/types/committee/event/index.ts
@@ -27,8 +27,8 @@ export interface CreateEventForm {
 
 export interface CreateEventRequest {
   title: string;
-  startAt: Date;
-  endAt: Date;
+  startAt: string;
+  endAt: string;
   participationDepartmentIds: number[];
   floors: {
     floorNumber: number;

--- a/src/types/common/sign-up/index.ts
+++ b/src/types/common/sign-up/index.ts
@@ -9,3 +9,8 @@ export interface SignUpFormData {
 export interface SubmitEmailData {
   email: string;
 }
+
+export interface SubmitCertificationCodeData {
+  email: string;
+  code: string;
+}

--- a/src/types/common/sign-up/index.ts
+++ b/src/types/common/sign-up/index.ts
@@ -4,6 +4,7 @@ export interface SignUpFormData {
   password: string;
   departmentId: number;
   phoneNumber: string;
+  studentNumber: string;
 }
 
 export interface SubmitEmailData {

--- a/src/types/common/sign-up/index.ts
+++ b/src/types/common/sign-up/index.ts
@@ -5,3 +5,7 @@ export interface SignUpFormData {
   departmentId: number;
   phoneNumber: string;
 }
+
+export interface SubmitEmailData {
+  email: string;
+}


### PR DESCRIPTION
### 개요

close #35 

### 작업사항

- 인증 메일 전송 api 연동
- 인증코드 인증 api 연동
- 회원가입 폼에 학번 필드 추가

### 변경로직

- 이벤트 생성 날짜의 데이터 저장 형식 변경ㅇ

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 회원가입 시 이메일 인증 기능이 추가되었습니다. 이메일 전송 및 인증번호 입력을 통한 인증이 가능합니다.
    - 회원가입 폼에 학번 입력란이 추가되었습니다.
    - 이메일 인증 요청 시 5분(300초) 카운트다운 타이머가 표시됩니다.

- **Bug Fixes**
    - 기존 휴대폰 인증 관련 입력란 및 검증 기능이 제거되었습니다.

- **Improvement**
    - 이벤트 생성 시 시작 및 종료 시간이 문자열(ISO 형식)로 처리됩니다.

- **Validation**
    - 학번 미입력 시 검증 메시지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->