### PR TITLE
refactor: 학생용과 위원회용 회원가입 폼 타입 분리

### DIFF
--- a/src/apis/committee/sign-up/index.ts
+++ b/src/apis/committee/sign-up/index.ts
@@ -1,6 +1,6 @@
 import { https } from "@/apis/https";
-import { SignUpFormData } from "@/types/common/sign-up";
+import { CommitteeSignUpFormData } from "@/types/committee/sign-up";
 
-export const postCommitteeSignUp = async (formData: SignUpFormData) => {
+export const postCommitteeSignUp = async (formData: CommitteeSignUpFormData) => {
   await https.post("auth/managers/signup", formData);
 };

--- a/src/apis/student/sign-up/index.ts
+++ b/src/apis/student/sign-up/index.ts
@@ -1,6 +1,6 @@
 import { https } from "@/apis/https";
-import { SignUpFormData } from "@/types/common/sign-up";
+import { StudentSignUpFormData } from "@/types/student/sign-up";
 
-export const postStudentSignUp = async (formData: SignUpFormData) => {
+export const postStudentSignUp = async (formData: StudentSignUpFormData) => {
   await https.post("auth/users/signup", formData);
 };

--- a/src/hooks/tanstack-query/committee/sign-up/index.ts
+++ b/src/hooks/tanstack-query/committee/sign-up/index.ts
@@ -2,14 +2,14 @@ import { useMutation } from "@tanstack/react-query";
 import { postCommitteeSignUp } from "@/apis/committee/sign-up";
 import { useRouter } from "next/navigation";
 import { ROUTE } from "@/constants/routes";
-import { SignUpFormData } from "@/types/common/sign-up";
 import { AxiosError } from "axios";
+import { CommitteeSignUpFormData } from "@/types/committee/sign-up";
 
 export const useCommitteeSignUp = () => {
   const router = useRouter();
   const { mutate } = useSignUpMutate();
 
-  const onCommitteeSignUp = (formData: SignUpFormData) => {
+  const onCommitteeSignUp = (formData: CommitteeSignUpFormData) => {
     mutate(formData, {
       onError: (error: AxiosError<{ message: string }>) => {
         alert(error.response?.data.message);
@@ -26,7 +26,7 @@ export const useCommitteeSignUp = () => {
 };
 
 export const useSignUpMutate = () => {
-  return useMutation<void, AxiosError<{ message: string }>, SignUpFormData>({
+  return useMutation<void, AxiosError<{ message: string }>, CommitteeSignUpFormData>({
     mutationKey: ["committeeSignUp"],
     mutationFn: postCommitteeSignUp,
   });

--- a/src/hooks/tanstack-query/student/sign-up/index.ts
+++ b/src/hooks/tanstack-query/student/sign-up/index.ts
@@ -1,15 +1,15 @@
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { ROUTE } from "@/constants/routes";
-import { SignUpFormData } from "@/types/common/sign-up";
 import { postStudentSignUp } from "@/apis/student/sign-up";
 import { AxiosError } from "axios";
+import { StudentSignUpFormData } from "@/types/student/sign-up";
 
 export const useStudentSignUp = () => {
   const router = useRouter();
   const { mutate } = useSignUpMutate();
 
-  const onStudentSignUp = (formData: SignUpFormData) => {
+  const onStudentSignUp = (formData: StudentSignUpFormData) => {
     mutate(formData, {
       onError: (error: AxiosError<{ message: string }>) => {
         alert(error.response?.data.message);
@@ -26,7 +26,7 @@ export const useStudentSignUp = () => {
 };
 
 export const useSignUpMutate = () => {
-  return useMutation<void, AxiosError<{ message: string }>, SignUpFormData>({
+  return useMutation<void, AxiosError<{ message: string }>, StudentSignUpFormData>({
     mutationKey: ["studentSignUp"],
     mutationFn: postStudentSignUp,
   });

--- a/src/types/common/sign-up/index.ts
+++ b/src/types/common/sign-up/index.ts
@@ -1,12 +1,3 @@
-export interface SignUpFormData {
-  name: string;
-  email: string;
-  password: string;
-  departmentId: number;
-  phoneNumber: string;
-  studentNumber: string;
-}
-
 export interface SubmitEmailData {
   email: string;
 }

--- a/src/types/student/sign-up/index.ts
+++ b/src/types/student/sign-up/index.ts
@@ -1,7 +1,8 @@
-export interface CommitteeSignUpFormData {
+export interface StudentSignUpFormData {
   name: string;
   email: string;
   password: string;
   departmentId: number;
   phoneNumber: string;
+  studentNumber: string;
 }


### PR DESCRIPTION
### 개요

close #37 

### 작업사항

- 학생용과 위원회용 회원가입 폼 타입 분리

### 변경로직

- 공통 회원가입 폼 타입 삭제

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- 위원회 및 학생 회원가입 관련 폼 데이터 타입이 각각의 역할에 맞게 분리되어 더욱 명확하게 관리됩니다.
- **Bug Fixes**
	- 회원가입 시 입력 데이터의 구조가 각 회원 유형에 맞게 정확하게 적용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->