### PR TITLE
feat: 특정 이벤트에 대한 신청 목록 조회 페이지 구현

### DIFF
--- a/src/apis/committee/apply/index.ts
+++ b/src/apis/committee/apply/index.ts
@@ -1,0 +1,13 @@
+import { ApplyDetailList } from "@/apis/dtos/committee/apply";
+import { https } from "@/apis/instance/https";
+
+export const getApplyDetail = async (
+  eventId: number,
+  page: number,
+  size: number,
+  direction: "asc" | "desc" = "asc",
+) => {
+  const { data } = await https.get(`events/${eventId}/registrations?page=${page}&size=${size}&direction=${direction}`);
+
+  return new ApplyDetailList(data);
+};

--- a/src/apis/committee/event/index.ts
+++ b/src/apis/committee/event/index.ts
@@ -1,5 +1,5 @@
 import { EventList } from "@/apis/dtos/committee/event";
-import { https } from "@/apis/https";
+import { https } from "@/apis/instance/https";
 import { CreateEventRequest } from "@/types/committee/event";
 
 export const postCreateEvent = async (formData: CreateEventRequest) => {

--- a/src/apis/committee/sign-up/index.ts
+++ b/src/apis/committee/sign-up/index.ts
@@ -1,4 +1,4 @@
-import { https } from "@/apis/https";
+import { https } from "@/apis/instance/https";
 import { CommitteeSignUpFormData } from "@/types/committee/sign-up";
 
 export const postCommitteeSignUp = async (formData: CommitteeSignUpFormData) => {

--- a/src/apis/common/sign-in/index.ts
+++ b/src/apis/common/sign-in/index.ts
@@ -1,4 +1,4 @@
-import { https } from "@/apis/https";
+import { https } from "@/apis/instance/https";
 import { SignInFormData } from "@/types/common/sign-in";
 
 export const postSignIn = async (formData: SignInFormData) => {

--- a/src/apis/common/sign-up/index.ts
+++ b/src/apis/common/sign-up/index.ts
@@ -1,5 +1,5 @@
 import { Department, Organization } from "@/apis/dtos/sign-up";
-import { https } from "@/apis/https";
+import { https } from "@/apis/instance/https";
 import { SubmitCertificationCodeData, SubmitEmailData } from "@/types/common/sign-up";
 
 export const getOrganizations = async (type: "COUNCIL" | "COMMITTEE") => {

--- a/src/apis/common/token/index.ts
+++ b/src/apis/common/token/index.ts
@@ -1,5 +1,9 @@
-import { https } from "@/apis/https";
+import { baseInstance } from "@/apis/instance/baseInstance";
 
 export const postReissue = async () => {
-  await https.post("auth/reissue", {});
+  try {
+    await baseInstance.post("auth/reissue", {});
+  } catch (error) {
+    console.log(error);
+  }
 };

--- a/src/apis/common/token/index.ts
+++ b/src/apis/common/token/index.ts
@@ -3,7 +3,10 @@ import { baseInstance } from "@/apis/instance/baseInstance";
 export const postReissue = async () => {
   try {
     await baseInstance.post("auth/reissue", {});
+
+    return true;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (error) {
-    console.log(error);
+    return false;
   }
 };

--- a/src/apis/dtos/committee/apply/index.ts
+++ b/src/apis/dtos/committee/apply/index.ts
@@ -1,0 +1,53 @@
+export class ApplyDetail {
+  floorNumber: number;
+  id: number;
+  lockerCode: string;
+  member: {
+    department: string;
+    email: string;
+    name: string;
+    organization: string;
+    studentNumber: string;
+  };
+
+  constructor({
+    floorNumber,
+    id,
+    lockerCode,
+    member: { department, email, name, organization, studentNumber },
+  }: {
+    floorNumber: number;
+    id: number;
+    lockerCode: string;
+    member: {
+      department: string;
+      email: string;
+      name: string;
+      organization: string;
+      studentNumber: string;
+    };
+  }) {
+    this.floorNumber = floorNumber;
+    this.id = id;
+    this.lockerCode = lockerCode;
+    this.member = {
+      department,
+      email,
+      name,
+      organization,
+      studentNumber,
+    };
+  }
+}
+
+export class ApplyDetailList {
+  content: ApplyDetail[];
+  totalElements: number;
+  isLast: boolean;
+
+  constructor({ content, totalElements, last }: { content: ApplyDetail[]; totalElements: number; last: boolean }) {
+    this.content = content;
+    this.totalElements = totalElements;
+    this.isLast = last;
+  }
+}

--- a/src/apis/instance/baseInstance.ts
+++ b/src/apis/instance/baseInstance.ts
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+export const baseInstance = axios.create({
+  baseURL: `${process.env.NEXT_PUBLIC_BASE_URL}v1/`,
+  headers: {
+    "Content-Type": "application/json",
+  },
+  withCredentials: true,
+});

--- a/src/apis/instance/https.ts
+++ b/src/apis/instance/https.ts
@@ -6,14 +6,7 @@ export const https = axios.create({
   headers: {
     "Content-Type": "application/json",
   },
-});
-
-https.interceptors.request.use((config) => {
-  if (typeof window !== "undefined") {
-    config.withCredentials = true;
-  }
-
-  return config;
+  withCredentials: true,
 });
 
 https.interceptors.response.use(

--- a/src/apis/instance/https.ts
+++ b/src/apis/instance/https.ts
@@ -18,9 +18,11 @@ https.interceptors.response.use(
 
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;
-      await postReissue();
+      const result = await postReissue();
 
-      return https(originalRequest);
+      if (result) {
+        return https(originalRequest);
+      }
     }
 
     return Promise.reject(error);

--- a/src/apis/student/apply-locker/index.ts
+++ b/src/apis/student/apply-locker/index.ts
@@ -1,5 +1,5 @@
 import { Locker, LockerList, MyRegistrationLocker } from "@/apis/dtos/student/locker";
-import { https } from "@/apis/https";
+import { https } from "@/apis/instance/https";
 
 export const getLockerList = async (eventId: number) => {
   const { data } = await https.get(`events/${eventId}/lockers`);

--- a/src/apis/student/sign-up/index.ts
+++ b/src/apis/student/sign-up/index.ts
@@ -1,4 +1,4 @@
-import { https } from "@/apis/https";
+import { https } from "@/apis/instance/https";
 import { StudentSignUpFormData } from "@/types/student/sign-up";
 
 export const postStudentSignUp = async (formData: StudentSignUpFormData) => {

--- a/src/app/committee/apply-list/[event-id]/page.tsx
+++ b/src/app/committee/apply-list/[event-id]/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import CommitteeHeader from "@/components/common/CommitteeHeader";
+import ApplyDetail from "@/components/page/committee/apply-detail";
+import { Suspense } from "react";
+
+export default function ApplyDetailPage() {
+  return (
+    <>
+      <CommitteeHeader />
+      <Suspense>
+        <ApplyDetail />
+      </Suspense>
+    </>
+  );
+}

--- a/src/app/committee/apply-list/page.tsx
+++ b/src/app/committee/apply-list/page.tsx
@@ -4,7 +4,7 @@ import CommitteeHeader from "@/components/common/CommitteeHeader";
 import ApplyList from "@/components/page/committee/apply-list";
 import { Suspense } from "react";
 
-export default function EventListPage() {
+export default function ApplyListPage() {
   return (
     <>
       <CommitteeHeader />

--- a/src/components/common/CommitteeHeader/index.module.scss
+++ b/src/components/common/CommitteeHeader/index.module.scss
@@ -14,6 +14,10 @@
   @include flexSort(row, null, center, 10rem);
 }
 
+.active {
+  color: $primary;
+}
+
 .headerTitle {
   font-size: 2.5rem !important;
 }

--- a/src/components/common/CommitteeHeader/index.tsx
+++ b/src/components/common/CommitteeHeader/index.tsx
@@ -31,7 +31,7 @@ export default function CommitteeHeader() {
             신청 목록
           </Txt>
         </Link>
-        <Link href={ROUTE.COMMITTEE.ANNOUNCEMENT}>
+        <Link href={ROUTE.COMMITTEE.ANNOUNCEMENT_LIST}>
           <Txt
             className={cn("headerTitle")}
             weight="medium"

--- a/src/components/common/CommitteeHeader/index.tsx
+++ b/src/components/common/CommitteeHeader/index.tsx
@@ -1,13 +1,18 @@
+"use client";
+
 import classNames from "classnames/bind";
 import styles from "./index.module.scss";
 import Link from "next/link";
 import { ROUTE } from "@/constants/routes";
 import Txt from "@/components/design-system/Txt";
 import ChnamLogo from "@/components/common/ChnamLogo/index";
+import { usePathname } from "next/navigation";
 
 const cn = classNames.bind(styles);
 
 export default function CommitteeHeader() {
+  const router = usePathname();
+
   return (
     <header className={cn("header")}>
       <Link href={ROUTE.COMMITTEE.APPLY_LIST} className={cn("logo")}>
@@ -18,17 +23,29 @@ export default function CommitteeHeader() {
       </Link>
       <div className={cn("linkContainer")}>
         <Link href={ROUTE.COMMITTEE.APPLY_LIST}>
-          <Txt className={cn("headerTitle")} weight="medium">
+          <Txt
+            className={cn("headerTitle")}
+            weight="medium"
+            color={router.includes("apply-list") ? "primary" : "black"}
+          >
             신청 목록
           </Txt>
         </Link>
         <Link href={ROUTE.COMMITTEE.ANNOUNCEMENT}>
-          <Txt className={cn("headerTitle")} weight="medium">
+          <Txt
+            className={cn("headerTitle")}
+            weight="medium"
+            color={router.includes("announcement-list") ? "primary" : "black"}
+          >
             공지사항
           </Txt>
         </Link>
         <Link href={ROUTE.COMMITTEE.EVENT_LIST}>
-          <Txt className={cn("headerTitle")} weight="medium">
+          <Txt
+            className={cn("headerTitle")}
+            weight="medium"
+            color={router.includes("event-list") ? "primary" : "black"}
+          >
             이벤트
           </Txt>
         </Link>

--- a/src/components/page/committee/apply-detail/index.module.scss
+++ b/src/components/page/committee/apply-detail/index.module.scss
@@ -1,0 +1,26 @@
+.container {
+  padding: 4rem;
+  @include flexSort(column, null, null, 3rem);
+}
+
+.table {
+  border: 0.2rem solid $primary;
+  border-bottom: 0;
+}
+
+.tableHeaderContainer {
+  background-color: $primary;
+}
+
+.tableHeader {
+  padding: 2rem;
+}
+
+.tr {
+  border-bottom: 0.2rem solid $primary;
+}
+
+.tableData {
+  text-align: center;
+  padding: 2rem;
+}

--- a/src/components/page/committee/apply-detail/index.module.scss
+++ b/src/components/page/committee/apply-detail/index.module.scss
@@ -1,3 +1,8 @@
+.skeleton {
+  width: 100%;
+  height: 30rem;
+}
+
 .container {
   padding: 4rem;
   @include flexSort(column, null, null, 3rem);

--- a/src/components/page/committee/apply-detail/index.tsx
+++ b/src/components/page/committee/apply-detail/index.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import Txt from "@/components/design-system/Txt";
+import Pagination from "@/components/common/Pagination";
+import { useApplyDetail } from "@/hooks/committee/event/useApplyDetail";
+
+const cn = classNames.bind(styles);
+
+export default function ApplyDetail() {
+  const { ApplyDetailList, totalElements, currentPage, setPage, itemsPerPage, pagesPerGroup } = useApplyDetail();
+
+  return (
+    <div className={cn("container")}>
+      <Txt color="primary" size="h3" weight="medium">
+        사물함 신청 현황
+      </Txt>
+      <table className={cn("table")}>
+        <thead className={cn("tableHeaderContainer")}>
+          <tr>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium">
+                층수
+              </Txt>
+            </th>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium">
+                사물함 이름
+              </Txt>
+            </th>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium">
+                학번
+              </Txt>
+            </th>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium">
+                소속
+              </Txt>
+            </th>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium">
+                학과
+              </Txt>
+            </th>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium">
+                이름
+              </Txt>
+            </th>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium">
+                이메일
+              </Txt>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {ApplyDetailList.map(({ floorNumber, id, lockerCode, member }) => (
+            <tr className={cn("tr")} key={id}>
+              <td className={cn("tableData")}>
+                <Txt size="h6">{floorNumber}</Txt>
+              </td>
+              <td className={cn("tableData")}>
+                <Txt size="h6">{lockerCode}</Txt>
+              </td>
+              <td className={cn("tableData")}>
+                <Txt size="h6">{member.studentNumber}</Txt>
+              </td>
+              <td className={cn("tableData")}>
+                <Txt size="h6">{member.organization}</Txt>
+              </td>
+              <td className={cn("tableData")}>
+                <Txt size="h6">{member.department}</Txt>
+              </td>
+              <td className={cn("tableData")}>
+                <Txt size="h6">{member.name}</Txt>
+              </td>
+              <td className={cn("tableData")}>
+                <Txt size="h6">{member.email}</Txt>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <Pagination
+        pagesPerGroup={pagesPerGroup}
+        currentPage={currentPage}
+        itemsPerPage={itemsPerPage}
+        totalItems={totalElements}
+        setPage={setPage}
+      />
+    </div>
+  );
+}

--- a/src/components/page/committee/apply-detail/index.tsx
+++ b/src/components/page/committee/apply-detail/index.tsx
@@ -5,11 +5,13 @@ import styles from "./index.module.scss";
 import Txt from "@/components/design-system/Txt";
 import Pagination from "@/components/common/Pagination";
 import { useApplyDetail } from "@/hooks/committee/event/useApplyDetail";
+import Skeleton from "@/components/common/Skeleton";
 
 const cn = classNames.bind(styles);
 
 export default function ApplyDetail() {
-  const { ApplyDetailList, totalElements, currentPage, setPage, itemsPerPage, pagesPerGroup } = useApplyDetail();
+  const { ApplyDetailList, isLoading, totalElements, currentPage, setPage, itemsPerPage, pagesPerGroup } =
+    useApplyDetail();
 
   return (
     <div className={cn("container")}>
@@ -57,31 +59,39 @@ export default function ApplyDetail() {
           </tr>
         </thead>
         <tbody>
-          {ApplyDetailList.map(({ floorNumber, id, lockerCode, member }) => (
-            <tr className={cn("tr")} key={id}>
-              <td className={cn("tableData")}>
-                <Txt size="h6">{floorNumber}</Txt>
-              </td>
-              <td className={cn("tableData")}>
-                <Txt size="h6">{lockerCode}</Txt>
-              </td>
-              <td className={cn("tableData")}>
-                <Txt size="h6">{member.studentNumber}</Txt>
-              </td>
-              <td className={cn("tableData")}>
-                <Txt size="h6">{member.organization}</Txt>
-              </td>
-              <td className={cn("tableData")}>
-                <Txt size="h6">{member.department}</Txt>
-              </td>
-              <td className={cn("tableData")}>
-                <Txt size="h6">{member.name}</Txt>
-              </td>
-              <td className={cn("tableData")}>
-                <Txt size="h6">{member.email}</Txt>
+          {isLoading ? (
+            <tr>
+              <td colSpan={7}>
+                <Skeleton className={cn("skeleton")} />
               </td>
             </tr>
-          ))}
+          ) : (
+            ApplyDetailList.map(({ floorNumber, id, lockerCode, member }) => (
+              <tr className={cn("tr")} key={id}>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{floorNumber}</Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{lockerCode}</Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{member.studentNumber}</Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{member.organization}</Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{member.department}</Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{member.name}</Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{member.email}</Txt>
+                </td>
+              </tr>
+            ))
+          )}
         </tbody>
       </table>
       <Pagination

--- a/src/components/page/committee/apply-list/index.module.scss
+++ b/src/components/page/committee/apply-list/index.module.scss
@@ -25,12 +25,6 @@
   }
 }
 
-.tableLink {
-  display: block;
-  width: 100%;
-  height: 100%;
-}
-
 .tableData {
   text-align: center;
   padding: 2rem;

--- a/src/components/page/committee/apply-list/index.module.scss
+++ b/src/components/page/committee/apply-list/index.module.scss
@@ -1,3 +1,8 @@
+.skeleton {
+  width: 100%;
+  height: 30rem;
+}
+
 .container {
   padding: 4rem;
   @include flexSort(column, null, null, 3rem);

--- a/src/components/page/committee/apply-list/index.tsx
+++ b/src/components/page/committee/apply-list/index.tsx
@@ -6,11 +6,13 @@ import Txt from "@/components/design-system/Txt";
 import Pagination from "@/components/common/Pagination";
 import { formatToKoreanTime } from "@/utils/date";
 import { useApplyList } from "@/hooks/committee/event/useApplyList";
+import Skeleton from "@/components/common/Skeleton";
 
 const cn = classNames.bind(styles);
 
 export default function ApplyList() {
-  const { eventList, totalElements, currentPage, setPage, itemsPerPage, pagesPerGroup, onApplyClick } = useApplyList();
+  const { applyList, totalElements, currentPage, setPage, itemsPerPage, pagesPerGroup, onApplyClick, isLoading } =
+    useApplyList();
 
   return (
     <div className={cn("container")}>
@@ -37,21 +39,31 @@ export default function ApplyList() {
             </th>
           </tr>
         </thead>
-        <tbody>
-          {eventList.map((event) => (
-            <tr className={cn("tr")} key={event.id} onClick={() => onApplyClick(event.id)}>
-              <td className={cn("tableData")}>
-                <Txt size="h6">{event.title}</Txt>
-              </td>
-              <td className={cn("tableData")}>
-                <Txt size="h6">{`${formatToKoreanTime(event.startAt)} ~ ${formatToKoreanTime(event.endAt)}`}</Txt>
-              </td>
-              <td className={cn("tableData")}>
-                <Txt size="h6">{event.status}</Txt>
+        {isLoading ? (
+          <tbody>
+            <tr>
+              <td colSpan={3}>
+                <Skeleton className={cn("skeleton")} />
               </td>
             </tr>
-          ))}
-        </tbody>
+          </tbody>
+        ) : (
+          <tbody>
+            {applyList.map((event) => (
+              <tr className={cn("tr")} key={event.id} onClick={() => onApplyClick(event.id)}>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{event.title}</Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{`${formatToKoreanTime(event.startAt)} ~ ${formatToKoreanTime(event.endAt)}`}</Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{event.status}</Txt>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        )}
       </table>
       <Pagination
         pagesPerGroup={pagesPerGroup}

--- a/src/components/page/committee/event-list/index.module.scss
+++ b/src/components/page/committee/event-list/index.module.scss
@@ -1,3 +1,8 @@
+.skeleton {
+  width: 100%;
+  height: 30rem;
+}
+
 .container {
   padding: 4rem;
   @include flexSort(column, null, null, 3rem);

--- a/src/components/page/committee/event-list/index.tsx
+++ b/src/components/page/committee/event-list/index.tsx
@@ -9,6 +9,7 @@ import Pagination from "@/components/common/Pagination";
 import { formatToKoreanTime } from "@/utils/date";
 import Link from "next/link";
 import { ROUTE } from "@/constants/routes";
+import Skeleton from "@/components/common/Skeleton";
 
 const cn = classNames.bind(styles);
 
@@ -22,6 +23,7 @@ export default function EventList() {
     pagesPerGroup,
     onDeleteEvent,
     onChangeEventPublish,
+    isLoading,
   } = useEventList();
 
   return (
@@ -72,47 +74,55 @@ export default function EventList() {
           </tr>
         </thead>
         <tbody>
-          {eventList.map((event) => (
-            <tr key={event.id} className={cn("tr")}>
-              <td className={cn("tableData")}>
-                <Txt size="h6">{event.title}</Txt>
-              </td>
-              <td className={cn("tableData")}>
-                <Txt size="h6">{`${formatToKoreanTime(event.startAt)} ~ ${formatToKoreanTime(event.endAt)}`}</Txt>
-              </td>
-              <td className={cn("tableData")}>
-                <Txt size="h6">{event.status}</Txt>
-              </td>
-              <td className={cn("tableData")}>
-                <Txt size="h6">{event.publish === true ? "공개" : "비공개"}</Txt>
-              </td>
-              <td className={cn("tableData", "publish")}>
-                <Button color="primary" className={cn("btn")} onClick={() => onChangeEventPublish(event.id, true)}>
-                  <Txt color="white" size="h6">
-                    공개
-                  </Txt>
-                </Button>
-                <Button color="gray" className={cn("btn")} onClick={() => onChangeEventPublish(event.id, false)}>
-                  <Txt size="h6">비공개</Txt>
-                </Button>
-              </td>
-              <td className={cn("tableData", "manage")}>
-                <Button
-                  color="red"
-                  className={cn("btn")}
-                  onClick={() => {
-                    if (confirm("이 이벤트를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.")) {
-                      onDeleteEvent(event.id);
-                    }
-                  }}
-                >
-                  <Txt color="white" size="h6">
-                    삭제
-                  </Txt>
-                </Button>
+          {isLoading ? (
+            <tr>
+              <td colSpan={6}>
+                <Skeleton className={cn("skeleton")} />
               </td>
             </tr>
-          ))}
+          ) : (
+            eventList.map((event) => (
+              <tr key={event.id} className={cn("tr")}>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{event.title}</Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{`${formatToKoreanTime(event.startAt)} ~ ${formatToKoreanTime(event.endAt)}`}</Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{event.status}</Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{event.publish === true ? "공개" : "비공개"}</Txt>
+                </td>
+                <td className={cn("tableData", "publish")}>
+                  <Button color="primary" className={cn("btn")} onClick={() => onChangeEventPublish(event.id, true)}>
+                    <Txt color="white" size="h6">
+                      공개
+                    </Txt>
+                  </Button>
+                  <Button color="gray" className={cn("btn")} onClick={() => onChangeEventPublish(event.id, false)}>
+                    <Txt size="h6">비공개</Txt>
+                  </Button>
+                </td>
+                <td className={cn("tableData", "manage")}>
+                  <Button
+                    color="red"
+                    className={cn("btn")}
+                    onClick={() => {
+                      if (confirm("이 이벤트를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.")) {
+                        onDeleteEvent(event.id);
+                      }
+                    }}
+                  >
+                    <Txt color="white" size="h6">
+                      삭제
+                    </Txt>
+                  </Button>
+                </td>
+              </tr>
+            ))
+          )}
         </tbody>
       </table>
       <Pagination

--- a/src/constants/routes/index.ts
+++ b/src/constants/routes/index.ts
@@ -12,7 +12,7 @@ export const ROUTE = {
     MAIN: "/committee/",
     SIGN_UP: "/committee/sign-up",
     APPLY_LIST: "/committee/apply-list",
-    ANNOUNCEMENT: "/committee/announcement",
+    ANNOUNCEMENT_LIST: "/committee/announcement-list",
     EVENT_LIST: "/committee/event-list",
     CREATE_EVENT: "/committee/create-event",
   },

--- a/src/hooks/committee/apply/useGetApplyDetailPageEventId.ts
+++ b/src/hooks/committee/apply/useGetApplyDetailPageEventId.ts
@@ -1,0 +1,10 @@
+import { usePathname } from "next/navigation";
+
+export const useGetApplyDetailPageEventId = () => {
+  const pathName = usePathname();
+  const eventId = Number(pathName.split("/").at(-1)) || 0;
+
+  return {
+    eventId,
+  };
+};

--- a/src/hooks/committee/event/useApplyDetail.ts
+++ b/src/hooks/committee/event/useApplyDetail.ts
@@ -1,0 +1,24 @@
+import { useGetPageParams } from "@/hooks/common/useGetPageParams";
+import { useApplyDetailPagination } from "@/hooks/committee/event/useApplyDetailPagination";
+import { useGetApplyDetailQuery } from "@/hooks/tanstack-query/committee/event/useGetApplyDetail";
+import { useGetApplyDetailPageEventId } from "../apply/useGetApplyDetailPageEventId";
+
+export const useApplyDetail = () => {
+  const { page: currentPage } = useGetPageParams();
+  const { eventId } = useGetApplyDetailPageEventId();
+
+  const { pagesPerGroup, queryParams, setPage } = useApplyDetailPagination(currentPage, eventId);
+  const { data } = useGetApplyDetailQuery(queryParams);
+
+  const ApplyDetailList = data?.content || [];
+  const totalElements = data?.totalElements || 0;
+
+  return {
+    ApplyDetailList,
+    totalElements,
+    currentPage,
+    setPage,
+    itemsPerPage: queryParams.size,
+    pagesPerGroup,
+  };
+};

--- a/src/hooks/committee/event/useApplyDetail.ts
+++ b/src/hooks/committee/event/useApplyDetail.ts
@@ -8,7 +8,7 @@ export const useApplyDetail = () => {
   const { eventId } = useGetApplyDetailPageEventId();
 
   const { pagesPerGroup, queryParams, setPage } = useApplyDetailPagination(currentPage, eventId);
-  const { data } = useGetApplyDetailQuery(queryParams);
+  const { data, isLoading } = useGetApplyDetailQuery(queryParams);
 
   const ApplyDetailList = data?.content || [];
   const totalElements = data?.totalElements || 0;
@@ -20,5 +20,6 @@ export const useApplyDetail = () => {
     setPage,
     itemsPerPage: queryParams.size,
     pagesPerGroup,
+    isLoading,
   };
 };

--- a/src/hooks/committee/event/useApplyDetailPagination.ts
+++ b/src/hooks/committee/event/useApplyDetailPagination.ts
@@ -1,0 +1,28 @@
+import { useRouter, useSearchParams } from "next/navigation";
+
+export const useApplyDetailPagination = (page: number, eventId: number) => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const pagesPerGroup = 5;
+
+  const setPage = (page: number) => {
+    const newParams = new URLSearchParams(searchParams.toString());
+    newParams.set("page", page.toString());
+
+    router.replace(`?${newParams.toString()}`);
+  };
+
+  const queryParams: { page: number; size: number; direction: "asc" | "desc"; eventId: number } = {
+    page: page - 1,
+    size: 10,
+    direction: "asc",
+    eventId,
+  };
+
+  return {
+    setPage,
+    pagesPerGroup,
+    queryParams,
+  };
+};

--- a/src/hooks/committee/event/useApplyList.ts
+++ b/src/hooks/committee/event/useApplyList.ts
@@ -1,4 +1,4 @@
-import { useGetEventPageParams } from "@/hooks/committee/event/useGetEventPageParams";
+import { useGetPageParams } from "@/hooks/common/useGetPageParams";
 import { useEventPagination } from "@/hooks/committee/event/useEventPagination";
 import { useGetApplyListQuery } from "@/hooks/tanstack-query/committee/event/useGetApplyList";
 import { useRouter } from "next/navigation";
@@ -6,7 +6,7 @@ import { ROUTE } from "@/constants/routes";
 
 export const useApplyList = () => {
   const router = useRouter();
-  const { page: currentPage } = useGetEventPageParams();
+  const { page: currentPage } = useGetPageParams();
   const { pagesPerGroup, queryParams, setPage } = useEventPagination(currentPage);
 
   const { data } = useGetApplyListQuery(queryParams);

--- a/src/hooks/committee/event/useApplyList.ts
+++ b/src/hooks/committee/event/useApplyList.ts
@@ -9,9 +9,9 @@ export const useApplyList = () => {
   const { page: currentPage } = useGetPageParams();
   const { pagesPerGroup, queryParams, setPage } = useEventPagination(currentPage);
 
-  const { data } = useGetApplyListQuery(queryParams);
+  const { data, isLoading } = useGetApplyListQuery(queryParams);
 
-  const eventList = data?.content || [];
+  const applyList = data?.content || [];
   const totalElements = data?.totalElements || 0;
 
   const onApplyClick = (eventId: number) => {
@@ -19,12 +19,13 @@ export const useApplyList = () => {
   };
 
   return {
-    eventList,
+    applyList,
     totalElements,
     currentPage,
     setPage,
     itemsPerPage: queryParams.size,
     pagesPerGroup,
     onApplyClick,
+    isLoading,
   };
 };

--- a/src/hooks/committee/event/useEventList.ts
+++ b/src/hooks/committee/event/useEventList.ts
@@ -8,7 +8,7 @@ export const useEventList = () => {
   const { page: currentPage } = useGetPageParams();
   const { pagesPerGroup, queryParams, setPage } = useEventPagination(currentPage);
 
-  const { data } = useGetEventListQuery(queryParams);
+  const { data, isLoading } = useGetEventListQuery(queryParams);
 
   const { onDeleteEvent } = useDeleteEvent(queryParams);
 
@@ -26,5 +26,6 @@ export const useEventList = () => {
     pagesPerGroup,
     onDeleteEvent,
     onChangeEventPublish,
+    isLoading,
   };
 };

--- a/src/hooks/committee/event/useEventList.ts
+++ b/src/hooks/committee/event/useEventList.ts
@@ -1,11 +1,11 @@
 import { useGetEventListQuery } from "@/hooks/tanstack-query/committee/event/useGetEventList";
-import { useGetEventPageParams } from "@/hooks/committee/event/useGetEventPageParams";
+import { useGetPageParams } from "@/hooks/common/useGetPageParams";
 import { useEventPagination } from "@/hooks/committee/event/useEventPagination";
 import { useDeleteEvent } from "@/hooks/tanstack-query/committee/event/useDeleteEvent";
 import { usePutEventPublish } from "@/hooks/tanstack-query/committee/event/usePutEventPublish";
 
 export const useEventList = () => {
-  const { page: currentPage } = useGetEventPageParams();
+  const { page: currentPage } = useGetPageParams();
   const { pagesPerGroup, queryParams, setPage } = useEventPagination(currentPage);
 
   const { data } = useGetEventListQuery(queryParams);

--- a/src/hooks/common/useGetPageParams.ts
+++ b/src/hooks/common/useGetPageParams.ts
@@ -1,6 +1,6 @@
 import { useSearchParams } from "next/navigation";
 
-export const useGetEventPageParams = () => {
+export const useGetPageParams = () => {
   const searchParams = useSearchParams();
 
   const page = Number(searchParams.get("page")) || 1;

--- a/src/hooks/tanstack-query/committee/event/useGetApplyDetail.ts
+++ b/src/hooks/tanstack-query/committee/event/useGetApplyDetail.ts
@@ -1,0 +1,17 @@
+import { getApplyDetail } from "@/apis/committee/apply";
+import { useQuery } from "@tanstack/react-query";
+
+interface ApplyDetailQueryParams {
+  page: number;
+  size: number;
+  direction?: "asc" | "desc";
+  eventId: number;
+}
+
+export const useGetApplyDetailQuery = ({ eventId, page, size, direction = "asc" }: ApplyDetailQueryParams) => {
+  return useQuery({
+    queryKey: ["applyDetail", eventId, page, size, direction],
+    queryFn: () => getApplyDetail(eventId, page, size, direction),
+    enabled: page >= 0,
+  });
+};


### PR DESCRIPTION
### 개요

close #48 

### 작업사항

- interceptor가 없는 instance 생성
- refresh token으로 access token을 불러오는 api의 인스턴스 변경
- 특정 이벤트에 대한 신청 목록 조회 페이지 구현
- 이벤트 목록 페이지, 신청 목록 페이지, 특정 이벤트에 대한 신청 목록 조회 페이지에 로딩 처리

### 변경로직

- https interceptor에서 request interceptor 제거

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 위원회 신청 목록에서 각 이벤트별 신청 내역을 확인할 수 있는 상세 페이지가 추가되었습니다.
  - 신청 상세 테이블에 페이지네이션 및 로딩 스켈레톤 UI가 도입되었습니다.
  - 신청 상세 데이터 조회를 위한 새로운 API 및 관련 훅이 추가되었습니다.

- **개선 및 스타일**
  - 위원회 헤더 메뉴에 현재 위치 표시(활성화 색상)가 적용되었습니다.
  - 신청 목록, 이벤트 목록 등 표 컴포넌트에 로딩 시 스켈레톤 UI가 추가되었습니다.

- **버그 수정**
  - 위원회 공지사항 경로가 정확하게 수정되었습니다.

- **리팩터링/정리**
  - 페이지네이션 및 데이터 조회 관련 훅과 API 구조가 개선되어 코드 일관성과 재사용성이 높아졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->