### PR TITLE
refactor: 위원회 로그인, 회원가입 페이지 변경

### DIFF
--- a/src/components/Layout/committee/AuthorizationLayout/index.module.scss
+++ b/src/components/Layout/committee/AuthorizationLayout/index.module.scss
@@ -1,6 +1,6 @@
 .container {
   @include flexSort(row, null, null, null);
-  min-height: 100%;
+  height: 100vh;
 }
 
 .logoContainer {

--- a/src/components/page/committee/Main/Form/index.module.scss
+++ b/src/components/page/committee/Main/Form/index.module.scss
@@ -26,3 +26,12 @@
   width: 100%;
   height: 5rem;
 }
+
+.linkContainer {
+  @include flexSort(row, flex-start, null, null);
+  width: 100%;
+}
+
+.link {
+  opacity: 0.6;
+}

--- a/src/components/page/committee/Main/Form/index.tsx
+++ b/src/components/page/committee/Main/Form/index.tsx
@@ -6,6 +6,8 @@ import styles from "./index.module.scss";
 import Txt from "@/components/design-system/Txt";
 import TextInput from "@/components/common/TextInput";
 import useCommitteeSignInForm from "@/hooks/committee/sign-in/useCommitteeSignInForm";
+import Link from "next/link";
+import { ROUTE } from "@/constants/routes";
 
 const cn = classNames.bind(styles);
 
@@ -45,6 +47,13 @@ export default function CommitteeSignInForm() {
           로그인
         </Txt>
       </Button>
+      <div className={cn("linkContainer")}>
+        <Link href={ROUTE.COMMITTEE.SIGN_UP}>
+          <Txt size="small" className={cn("link")}>
+            회원가입
+          </Txt>
+        </Link>
+      </div>
     </form>
   );
 }

--- a/src/components/page/committee/SignUp/Form/index.module.scss
+++ b/src/components/page/committee/SignUp/Form/index.module.scss
@@ -1,6 +1,8 @@
 .form {
+  height: 100%;
   @include flexSort(column, null, center, 2rem);
   width: 40rem;
+  padding: 10rem 0;
 }
 
 .title {
@@ -31,10 +33,6 @@
 
 .errorMessage {
   margin-top: 2rem;
-}
-
-.btnContainer {
-  margin-top: 5rem;
 }
 
 .completeBtn {

--- a/src/components/page/committee/SignUp/index.module.scss
+++ b/src/components/page/committee/SignUp/index.module.scss
@@ -1,5 +1,5 @@
 .container {
   @include flexSort(row, center, center, null);
   flex: 1;
-  padding: 10rem 0;
+  overflow-y: scroll;
 }


### PR DESCRIPTION
### 개요

close #55 

### 작업사항

- 로그인 페이지에 회원가입 페이지로 이동하는 Link 태그 추가
- 회원가입, 로그인 페이지 전체 영역의 높이를 100vh로 설정하고 회원 가입 페이지의 오른쪽 영역을 overflow-y를 scroll로 변경

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 위원회 로그인 폼에 "회원가입" 링크가 추가되어, 회원가입 페이지로 쉽게 이동할 수 있습니다.

- **Style**
  - 일부 컨테이너와 폼의 높이 및 패딩이 조정되어 레이아웃이 개선되었습니다.
  - 링크 컨테이너와 링크에 새로운 스타일이 적용되어 시각적 구분이 향상되었습니다.
  - 회원가입 페이지에 스크롤이 추가되어 긴 내용도 편리하게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->