### PR TITLE
feat: 위원회 페이지에 나의 학과 정보 api 연동

### DIFF
--- a/src/components/common/CommitteeHeader/index.module.scss
+++ b/src/components/common/CommitteeHeader/index.module.scss
@@ -28,9 +28,10 @@
 }
 
 .departmentContainer {
-  width: 30rem;
+  max-width: 30rem;
   font-size: 2.5rem;
   border: 0.1rem solid black;
   padding: 1rem 3rem;
   border-radius: 1rem;
+  @include flexSort(row, center, center, null);
 }

--- a/src/components/common/CommitteeHeader/index.module.scss
+++ b/src/components/common/CommitteeHeader/index.module.scss
@@ -1,3 +1,8 @@
+.skeleton {
+  width: 30rem;
+  height: 5rem;
+}
+
 .header {
   width: 100%;
   @include flexSort(row, space-between, center, null);
@@ -23,6 +28,7 @@
 }
 
 .departmentContainer {
+  width: 30rem;
   font-size: 2.5rem;
   border: 0.1rem solid black;
   padding: 1rem 3rem;

--- a/src/components/common/CommitteeHeader/index.tsx
+++ b/src/components/common/CommitteeHeader/index.tsx
@@ -7,11 +7,18 @@ import { ROUTE } from "@/constants/routes";
 import Txt from "@/components/design-system/Txt";
 import ChnamLogo from "@/components/common/ChnamLogo/index";
 import { usePathname } from "next/navigation";
+import { useGetMyInfo } from "@/hooks/tanstack-query/common/my-info/useGetMyInfo";
+import Skeleton from "../Skeleton";
 
 const cn = classNames.bind(styles);
 
 export default function CommitteeHeader() {
   const router = usePathname();
+  const { data, isPending, isError } = useGetMyInfo();
+
+  if (isError) {
+    return;
+  }
 
   return (
     <header className={cn("header")}>
@@ -50,9 +57,13 @@ export default function CommitteeHeader() {
           </Txt>
         </Link>
       </div>
-      <div className={cn("departmentContainer")}>
-        <Txt className={cn("headerTitle")}>수학과</Txt>
-      </div>
+      {isPending ? (
+        <Skeleton className={cn("skeleton")} />
+      ) : (
+        <div className={cn("departmentContainer")}>
+          <Txt className={cn("headerTitle")}>{data.affiliation}</Txt>
+        </div>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
### 개요

close #57 

### 작업사항

- 위원회 페이지에 나의 학과 정보 api 연동
- 학과 정보를 보여주는 ui의 글씨가 영역의 중간에 오게 변경

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 사용자 정보를 비동기로 불러와 학과명이 자동으로 표시됩니다.
  - 사용자 정보 로딩 중에는 스켈레톤 로딩 플래이스홀더가 표시됩니다.

- **스타일**
  - 스켈레톤 스타일이 추가되고, 학과명 컨테이너의 정렬 및 크기가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->