### PR TITLE
refactor: 학생 회원 가입 페이지에서 이메일 전송 버튼 클릭 시 전남대 이메일로 유효성 검사

### DIFF
--- a/src/hooks/committee/sign-up/useCommitteeSignUpForm.ts
+++ b/src/hooks/committee/sign-up/useCommitteeSignUpForm.ts
@@ -1,7 +1,7 @@
 import { FormEvent } from "react";
 import { COMMITTEE_SIGN_UP, VALIDATION_TYPES } from "@/constants/error";
 import { useCommitteeSignUp } from "@/hooks/tanstack-query/committee/sign-up";
-import { isEmail, isPassword } from "@/utils/validator";
+import { isJnuEmail, isPassword } from "@/utils/validator";
 import { useDepartmentsQuery, useOrganizationsQuery } from "@/hooks/tanstack-query/common/sign-up";
 import { useCommitteeFormData } from "@/hooks/committee/sign-up/useCommitteeFormData";
 import { useFormError } from "@/hooks/common/useFormError";
@@ -37,7 +37,7 @@ const useCommitteeSignUpForm = () => {
         return COMMITTEE_SIGN_UP[field][VALIDATION_TYPES.REQUIRED];
       }
 
-      if (field === "email" && formData.category.value === "학생회" && !isEmail(formData.email)) {
+      if (field === "email" && formData.category.value === "학생회" && !isJnuEmail(formData.email)) {
         return COMMITTEE_SIGN_UP[field][VALIDATION_TYPES.FORMAT];
       }
       if (field === "email" && !formData.email) {

--- a/src/hooks/student/enter-email/useEnterEmail.ts
+++ b/src/hooks/student/enter-email/useEnterEmail.ts
@@ -1,5 +1,5 @@
 import { ChangeEvent, FormEvent, useState } from "react";
-import { isEmail } from "@/utils/validator";
+import { isJnuEmail } from "@/utils/validator";
 import { ENTER_EMAIL, VALIDATION_TYPES } from "@/constants/error";
 
 const useEnterEmail = () => {
@@ -19,7 +19,7 @@ const useEnterEmail = () => {
       }
     }
 
-    if (!isEmail(formData.email)) {
+    if (!isJnuEmail(formData.email)) {
       return ENTER_EMAIL.email[VALIDATION_TYPES.FORMAT];
     }
 

--- a/src/hooks/student/sign-in/useStudentSignInForm.ts
+++ b/src/hooks/student/sign-in/useStudentSignInForm.ts
@@ -1,5 +1,5 @@
 import { FormEvent } from "react";
-import { isEmail, isPassword } from "@/utils/validator";
+import { isJnuEmail, isPassword } from "@/utils/validator";
 import { SIGN_IN, VALIDATION_TYPES } from "@/constants/error";
 import { useStudentSignIn } from "@/hooks/tanstack-query/student/sign-in";
 import { useFormError } from "@/hooks/common/useFormError";
@@ -20,7 +20,7 @@ const useStudentSignInForm = () => {
       }
     }
 
-    if (!isEmail(formData.email)) {
+    if (!isJnuEmail(formData.email)) {
       return SIGN_IN.email[VALIDATION_TYPES.FORMAT];
     }
 

--- a/src/hooks/student/sign-up/useStudentSignUp.ts
+++ b/src/hooks/student/sign-up/useStudentSignUp.ts
@@ -1,5 +1,5 @@
 import { FormEvent } from "react";
-import { isEmail, isPassword } from "@/utils/validator";
+import { isJnuEmail, isPassword } from "@/utils/validator";
 import { STUDENT_SIGN_UP, VALIDATION_TYPES } from "@/constants/error";
 import {
   useDepartmentsQuery,
@@ -50,7 +50,7 @@ const useStudentSignUpForm = () => {
         return STUDENT_SIGN_UP[field][VALIDATION_TYPES.REQUIRED];
       }
 
-      if (field === "email" && !isEmail(formData.email)) {
+      if (field === "email" && !isJnuEmail(formData.email)) {
         return STUDENT_SIGN_UP[field][VALIDATION_TYPES.FORMAT];
       }
       if (field === "email" && !formData.email) {

--- a/src/hooks/tanstack-query/common/sign-up/index.ts
+++ b/src/hooks/tanstack-query/common/sign-up/index.ts
@@ -1,6 +1,7 @@
 import { getDepartments, getOrganizations, postSubmitEmail, postVerifyCertificationCode } from "@/apis/common/sign-up";
 import { ApiResponseError } from "@/types/common/api";
 import { SubmitCertificationCodeData, SubmitEmailData } from "@/types/common/sign-up";
+import { isJnuEmail } from "@/utils/validator";
 import { useQuery } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
 import { Dispatch, SetStateAction } from "react";
@@ -42,6 +43,11 @@ export const useSubmitEmail = (
   const { mutate } = useSubmitEmailMutate();
 
   const onSubmitEmail = (data: SubmitEmailData) => {
+    if (!isJnuEmail(data.email)) {
+      alert("전남대학교 학생 이메일을 입력해주세요.");
+      return;
+    }
+
     mutate(data, {
       onError: (error) => {
         alert(error.response.data.message || "이메일 전송에 실패했습니다.");

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,4 +1,4 @@
-export const isEmail = (email: string) => /^[a-zA-Z0-9._%+-]+@jnu\.ac\.kr$/.test(email);
+export const isJnuEmail = (email: string) => /^[a-zA-Z0-9._%+-]+@jnu\.ac\.kr$/.test(email);
 
 export const isPassword = (password: string) =>
   /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+{}\[\]:;<>,.?/~\\-]).{9,}$/.test(password);


### PR DESCRIPTION
### 개요

close #63 

### 작업사항

- 학생 회원가입 페이지에서 이메일 전송 버튼 클릭 시 전남대 이메일로 유효성 검사

### 변경로직

- isEmail 함수명 변경 (isJnuEmail)

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 이메일 입력 및 회원가입, 로그인, 학생회 가입 등에서 이메일 유효성 검사가 전남대학교(@jnu.ac.kr) 이메일로만 제한되도록 변경되었습니다.
	- 전남대학교 학생 이메일이 아닌 경우 안내 메시지가 표시되고 제출이 차단됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->