### PR TITLE
feat: 이벤트 생성 시 이벤트 리스트 다시 불러오기

### DIFF
--- a/src/apis/committee/event/index.ts
+++ b/src/apis/committee/event/index.ts
@@ -7,7 +7,7 @@ export const postCreateEvent = async (formData: CreateEventRequest) => {
 };
 
 export const getEventList = async (page: number, size: number, direction: "asc" | "desc" = "asc") => {
-  const { data } = await https.get(`events?page=${page}&size=${size}&direction=${direction}`);
+  const { data } = await https.get(`events?page=${page}&size=${size}&direction=${direction}&sort=createdAt`);
 
   return new EventList(data);
 };

--- a/src/apis/committee/event/index.ts
+++ b/src/apis/committee/event/index.ts
@@ -6,7 +6,7 @@ export const postCreateEvent = async (formData: CreateEventRequest) => {
   await https.post("events", formData);
 };
 
-export const getEventList = async (page: number, size: number, direction: "asc" | "desc" = "asc") => {
+export const getEventList = async (page: number, size: number, direction: "asc" | "desc") => {
   const { data } = await https.get(`events?page=${page}&size=${size}&direction=${direction}&sort=createdAt`);
 
   return new EventList(data);

--- a/src/hooks/committee/event/useEventPagination.ts
+++ b/src/hooks/committee/event/useEventPagination.ts
@@ -16,7 +16,7 @@ export const useEventPagination = (page: number) => {
   const queryParams: { page: number; size: number; direction: "asc" | "desc" } = {
     page: page - 1,
     size: 4,
-    direction: "asc",
+    direction: "desc",
   };
 
   return {

--- a/src/hooks/tanstack-query/committee/event/useCreateEvent.ts
+++ b/src/hooks/tanstack-query/committee/event/useCreateEvent.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { ROUTE } from "@/constants/routes";
 import { postCreateEvent } from "@/apis/committee/event";
@@ -9,6 +9,7 @@ import { ApiResponseError } from "@/types/common/api";
 export const useCreateEvent = () => {
   const router = useRouter();
   const { mutate } = useCreateEventMutate();
+  const queryClient = useQueryClient();
 
   const onCreateEvent = (formData: CreateEventForm) => {
     if (!formData.title) {
@@ -64,6 +65,8 @@ export const useCreateEvent = () => {
         alert(error.response.data.message || "이벤트 생성에 실패하였습니다.");
       },
       onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ["eventList", 0, 4, "desc"] });
+        queryClient.invalidateQueries({ queryKey: ["applyList", 0, 4, "desc"] });
         router.push(ROUTE.COMMITTEE.EVENT_LIST);
         alert("이벤트 생성에 성공하셨습니다.");
       },

--- a/src/hooks/tanstack-query/committee/event/useCreateEvent.ts
+++ b/src/hooks/tanstack-query/committee/event/useCreateEvent.ts
@@ -5,11 +5,16 @@ import { postCreateEvent } from "@/apis/committee/event";
 import { CreateEventForm, CreateEventRequest } from "@/types/committee/event";
 import { convertToKST } from "@/functions/date";
 import { ApiResponseError } from "@/types/common/api";
+import { useQueryKeys } from "../../common/useQueryKeys";
 
 export const useCreateEvent = () => {
   const router = useRouter();
   const { mutate } = useCreateEventMutate();
   const queryClient = useQueryClient();
+
+  const eventQueryKeys = useQueryKeys(["eventList"]);
+
+  const applyQueryKeys = useQueryKeys(["applyList"]);
 
   const onCreateEvent = (formData: CreateEventForm) => {
     if (!formData.title) {
@@ -65,8 +70,14 @@ export const useCreateEvent = () => {
         alert(error.response.data.message || "이벤트 생성에 실패하였습니다.");
       },
       onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: ["eventList", 0, 4, "desc"] });
-        queryClient.invalidateQueries({ queryKey: ["applyList", 0, 4, "desc"] });
+        eventQueryKeys.forEach((queryKey) => {
+          queryClient.invalidateQueries({ queryKey });
+        });
+
+        applyQueryKeys.forEach((queryKey) => {
+          queryClient.invalidateQueries({ queryKey });
+        });
+
         router.push(ROUTE.COMMITTEE.EVENT_LIST);
         alert("이벤트 생성에 성공하셨습니다.");
       },

--- a/src/hooks/tanstack-query/committee/event/useGetApplyList.ts
+++ b/src/hooks/tanstack-query/committee/event/useGetApplyList.ts
@@ -4,10 +4,10 @@ import { useQuery } from "@tanstack/react-query";
 interface ApplyListQueryParams {
   page: number;
   size: number;
-  direction?: "asc" | "desc";
+  direction: "asc" | "desc";
 }
 
-export const useGetApplyListQuery = ({ page, size, direction = "asc" }: ApplyListQueryParams) => {
+export const useGetApplyListQuery = ({ page, size, direction }: ApplyListQueryParams) => {
   return useQuery({
     queryKey: ["applyList", page, size, direction],
     queryFn: () => getEventList(page, size, direction),

--- a/src/hooks/tanstack-query/committee/event/useGetEventList.ts
+++ b/src/hooks/tanstack-query/committee/event/useGetEventList.ts
@@ -4,10 +4,10 @@ import { useQuery } from "@tanstack/react-query";
 interface EventListQueryParams {
   page: number;
   size: number;
-  direction?: "asc" | "desc";
+  direction: "asc" | "desc";
 }
 
-export const useGetEventListQuery = ({ page, size, direction = "asc" }: EventListQueryParams) => {
+export const useGetEventListQuery = ({ page, size, direction }: EventListQueryParams) => {
   return useQuery({
     queryKey: ["eventList", page, size, direction],
     queryFn: () => getEventList(page, size, direction),

--- a/src/hooks/tanstack-query/common/useQueryKeys.ts
+++ b/src/hooks/tanstack-query/common/useQueryKeys.ts
@@ -1,0 +1,11 @@
+import { useQueryClient } from "@tanstack/react-query";
+
+export const useQueryKeys = (queryKey: string[]) => {
+  const queryClient = useQueryClient();
+
+  const allQueries = queryClient.getQueriesData({
+    queryKey,
+  });
+
+  return allQueries.map(([key]) => key);
+};


### PR DESCRIPTION
### 개요

close #65 

### 작업사항

- 이벤트 생성 시 이벤트 리스트 다시 불러오기

### 변경로직

- 이벤트 목록의 정렬 기준을 createdAt, direction을 desc로 설정

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
    - 이벤트 및 신청 목록 조회 시 정렬 방향이 명확하게 지정되어, 최신순(내림차순)으로 표시됩니다.
- **신규 기능**
    - 이벤트 생성 후, 이벤트 목록과 신청 목록이 자동으로 새로고침되어 최신 정보가 바로 반영됩니다.
- **문서화**
    - 이벤트 및 신청 목록 조회 시 정렬 방향 파라미터가 필수로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->