### PR TITLE
refactor: 학생 사물함 신청 페이지에서 나의 사물함 신청 취소 시 나의 사물함 신청 현황 api 재호출

### DIFF
--- a/src/components/page/student/ApplyLocker/ApplyLockerStatusTable/index.tsx
+++ b/src/components/page/student/ApplyLocker/ApplyLockerStatusTable/index.tsx
@@ -9,10 +9,14 @@ import Skeleton from "@/components/common/Skeleton";
 const cn = classNames.bind(styles);
 
 export default function ApplyLockerStatusTable() {
-  const { myRegistrationLocker, onDeleteMyRegistrationLocker, isLoading } = useMyRegistrationLocker();
+  const { myRegistrationLocker, onDeleteMyRegistrationLocker, isPending, isError } = useMyRegistrationLocker();
 
-  if (isLoading) {
+  if (isPending) {
     return <Skeleton className={cn("skeleton")} />;
+  }
+
+  if (isError) {
+    return null;
   }
 
   return (
@@ -30,19 +34,17 @@ export default function ApplyLockerStatusTable() {
           </th>
         </tr>
       </thead>
-      {myRegistrationLocker && (
-        <tbody>
-          <tr key={myRegistrationLocker.lockerId}>
-            <td className={cn("td")}>{myRegistrationLocker.floorNumber}층</td>
-            <td className={cn("td")}>{myRegistrationLocker.lockerName}</td>
-            <td className={cn("deleteBtnContainer")}>
-              <button className={cn("deleteBtn")} onClick={onDeleteMyRegistrationLocker}>
-                삭제
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      )}
+      <tbody>
+        <tr key={myRegistrationLocker?.lockerId}>
+          <td className={cn("td")}>{myRegistrationLocker?.floorNumber}층</td>
+          <td className={cn("td")}>{myRegistrationLocker?.lockerName}</td>
+          <td className={cn("deleteBtnContainer")}>
+            <button className={cn("deleteBtn")} onClick={onDeleteMyRegistrationLocker}>
+              삭제
+            </button>
+          </td>
+        </tr>
+      </tbody>
     </table>
   );
 }

--- a/src/components/page/student/ApplyLocker/ApplyLockerStatusTable/index.tsx
+++ b/src/components/page/student/ApplyLocker/ApplyLockerStatusTable/index.tsx
@@ -34,17 +34,19 @@ export default function ApplyLockerStatusTable() {
           </th>
         </tr>
       </thead>
-      <tbody>
-        <tr key={myRegistrationLocker?.lockerId}>
-          <td className={cn("td")}>{myRegistrationLocker?.floorNumber}층</td>
-          <td className={cn("td")}>{myRegistrationLocker?.lockerName}</td>
-          <td className={cn("deleteBtnContainer")}>
-            <button className={cn("deleteBtn")} onClick={onDeleteMyRegistrationLocker}>
-              삭제
-            </button>
-          </td>
-        </tr>
-      </tbody>
+      {myRegistrationLocker && (
+        <tbody>
+          <tr key={myRegistrationLocker.lockerId}>
+            <td className={cn("td")}>{myRegistrationLocker.floorNumber}층</td>
+            <td className={cn("td")}>{myRegistrationLocker.lockerName}</td>
+            <td className={cn("deleteBtnContainer")}>
+              <button className={cn("deleteBtn")} onClick={onDeleteMyRegistrationLocker}>
+                삭제
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      )}
     </table>
   );
 }

--- a/src/hooks/student/apply-locker/useMyRegistrationLocker.ts
+++ b/src/hooks/student/apply-locker/useMyRegistrationLocker.ts
@@ -5,13 +5,14 @@ import { useGetMyRegistrationLocker } from "@/hooks/tanstack-query/student/apply
 export const useMyRegistrationLocker = () => {
   const { eventId } = useGetApplyLockerPageEventId();
 
-  const { data: myRegistrationLocker, isLoading } = useGetMyRegistrationLocker(eventId);
+  const { data: myRegistrationLocker, isPending, isError } = useGetMyRegistrationLocker(eventId);
 
   const { onDeleteMyRegistrationLocker } = useDeleteMyRegistrationLocker(eventId);
 
   return {
     myRegistrationLocker,
     onDeleteMyRegistrationLocker,
-    isLoading,
+    isPending,
+    isError,
   };
 };


### PR DESCRIPTION
### 개요

close #67 

### 작업사항

- 학생 사물함 신청 페이지에서 나의 사물함 신청 취소 시 나의 사물함 신청 현황 api 재호출

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 사물함 신청 상태 테이블에서 로딩 및 오류 상태 처리 방식이 개선되었습니다. 오류 발생 시 테이블이 표시되지 않도록 변경되었습니다.

- **리팩터**
  - 로딩 상태가 `isLoading`에서 `isPending`으로 변경되고, 오류 상태(`isError`)가 추가되어 상태 관리가 명확해졌습니다.  
  - 테이블 본문 렌더링 로직이 간소화되어 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->