### PR TITLE
feat: 가입 승인 대기 페이지 구현

### DIFF
--- a/src/apis/committee/approve-wait/index.ts
+++ b/src/apis/committee/approve-wait/index.ts
@@ -1,0 +1,15 @@
+import { ApproveWaitList } from "@/apis/dtos/committee/approve-wait";
+import { https } from "@/apis/instance/https";
+import { ApproveWaitRequest } from "@/types/committee/approve-wait";
+
+export const getApproveWaitList = async (page: number, size: number, direction: "asc" | "desc") => {
+  const { data } = await https.get(
+    `auth/managers/pending?page=${page}&size=${size}&direction=${direction}&sort=createdAt`,
+  );
+
+  return new ApproveWaitList(data);
+};
+
+export const postApproveWait = async (formData: ApproveWaitRequest) => {
+  await https.post("auth/managers/approve", formData);
+};

--- a/src/apis/dtos/committee/approve-wait/index.ts
+++ b/src/apis/dtos/committee/approve-wait/index.ts
@@ -1,0 +1,39 @@
+export class ApproveWait {
+  memberId: number;
+  studentNumber: string;
+  name: string;
+  createdAt: Date;
+  email: string;
+
+  constructor({
+    createdAt,
+    email,
+    memberId,
+    name,
+    studentNumber,
+  }: {
+    memberId: number;
+    studentNumber: string;
+    name: string;
+    createdAt: Date;
+    email: string;
+  }) {
+    this.memberId = memberId;
+    this.studentNumber = studentNumber;
+    this.name = name;
+    this.createdAt = createdAt;
+    this.email = email;
+  }
+}
+
+export class ApproveWaitList {
+  content: ApproveWait[];
+  totalElements: number;
+  isLast: boolean;
+
+  constructor({ content, totalElements, last }: { content: ApproveWait[]; totalElements: number; last: boolean }) {
+    this.content = content;
+    this.totalElements = totalElements;
+    this.isLast = last;
+  }
+}

--- a/src/apis/dtos/common/my-info/index.ts
+++ b/src/apis/dtos/common/my-info/index.ts
@@ -5,6 +5,7 @@ export class MyInfo {
   affiliation: string;
   phoneNumber: string;
   email: string;
+  role: "MANAGER" | "ADMIN" | "USER" | "GUEST";
 
   constructor({
     memberId,
@@ -13,6 +14,7 @@ export class MyInfo {
     affiliation,
     phoneNumber,
     email,
+    role,
   }: {
     memberId: number;
     name: string;
@@ -20,6 +22,7 @@ export class MyInfo {
     affiliation: string;
     phoneNumber: string;
     email: string;
+    role: "MANAGER" | "ADMIN" | "USER" | "GUEST";
   }) {
     this.memberId = memberId;
     this.name = name;
@@ -27,5 +30,6 @@ export class MyInfo {
     this.affiliation = affiliation;
     this.phoneNumber = phoneNumber;
     this.email = email;
+    this.role = role;
   }
 }

--- a/src/app/committee/approve-wait/page.tsx
+++ b/src/app/committee/approve-wait/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import CommitteeHeader from "@/components/common/CommitteeHeader";
+import ApproveWait from "@/components/page/approve-wait";
+import { Suspense } from "react";
+
+export default function ApproveWaitPage() {
+  return (
+    <>
+      <CommitteeHeader />
+      <Suspense>
+        <ApproveWait />
+      </Suspense>
+    </>
+  );
+}

--- a/src/components/common/CommitteeHeader/index.module.scss
+++ b/src/components/common/CommitteeHeader/index.module.scss
@@ -1,3 +1,8 @@
+.linkSkeleton {
+  width: 10rem;
+  height: 5rem;
+}
+
 .skeleton {
   width: 30rem;
   height: 5rem;

--- a/src/components/common/CommitteeHeader/index.tsx
+++ b/src/components/common/CommitteeHeader/index.tsx
@@ -46,6 +46,21 @@ export default function CommitteeHeader() {
             이벤트
           </Txt>
         </Link>
+        {isPending ? (
+          <Skeleton className={cn("linkSkeleton")} />
+        ) : (
+          data?.role === "MANAGER" && (
+            <Link href={ROUTE.COMMITTEE.APPROVE_WAIT}>
+              <Txt
+                className={cn("headerTitle")}
+                weight="medium"
+                color={path.includes("approve-wait") ? "primary" : "black"}
+              >
+                승인 대기
+              </Txt>
+            </Link>
+          )
+        )}
       </div>
       {isPending ? (
         <Skeleton className={cn("skeleton")} />

--- a/src/components/page/approve-wait/index.module.scss
+++ b/src/components/page/approve-wait/index.module.scss
@@ -1,0 +1,50 @@
+.skeleton {
+  width: 100%;
+  height: 30rem;
+}
+
+.container {
+  padding: 4rem;
+  @include flexSort(column, null, null, 3rem);
+}
+
+.table {
+  border: 0.2rem solid $primary;
+  border-bottom: 0;
+}
+
+.tableHeaderContainer {
+  background-color: $primary;
+}
+
+.tableHeader {
+  padding: 2rem;
+}
+
+.tr {
+  border-bottom: 0.2rem solid $primary;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f0f0f0;
+  }
+}
+
+.tableData {
+  text-align: center;
+  padding: 1.5rem;
+}
+
+.publish {
+  @include flexSort(row, center, center, 1rem);
+}
+
+.manage {
+  button {
+    margin: 0 auto;
+  }
+}
+
+.btn {
+  padding: 1rem 1.5rem;
+}

--- a/src/components/page/approve-wait/index.tsx
+++ b/src/components/page/approve-wait/index.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import Txt from "@/components/design-system/Txt";
+import Button from "@/components/design-system/Button";
+import Pagination from "@/components/common/Pagination";
+import { formatToKoreanTime } from "@/utils/date";
+import Skeleton from "@/components/common/Skeleton";
+import { useApproveWaitList } from "@/hooks/committee/approve-wait/useApproveWaitList";
+
+const cn = classNames.bind(styles);
+
+export default function ApproveWait() {
+  const { approveWaitList, totalElements, currentPage, setPage, itemsPerPage, pagesPerGroup, isLoading, onApprove } =
+    useApproveWaitList();
+
+  return (
+    <div className={cn("container")}>
+      <Txt color="primary" size="h3" weight="medium">
+        MANAGER 가입 승인 대기 목록
+      </Txt>
+      <table className={cn("table")}>
+        <thead className={cn("tableHeaderContainer")}>
+          <tr>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium">
+                학번
+              </Txt>
+            </th>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium">
+                이름
+              </Txt>
+            </th>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium">
+                신청일
+              </Txt>
+            </th>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium">
+                이메일
+              </Txt>
+            </th>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium">
+                관리
+              </Txt>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {isLoading ? (
+            <tr>
+              <td colSpan={5}>
+                <Skeleton className={cn("skeleton")} />
+              </td>
+            </tr>
+          ) : (
+            approveWaitList.map((approveWait) => (
+              <tr key={approveWait.memberId} className={cn("tr")}>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{approveWait.studentNumber}</Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{approveWait.name}</Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{`${formatToKoreanTime(approveWait.createdAt)}`}</Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6">{approveWait.email}</Txt>
+                </td>
+                <td className={cn("tableData", "publish")}>
+                  <Button
+                    color="primary"
+                    className={cn("btn")}
+                    onClick={() => onApprove({ memberId: approveWait.memberId })}
+                  >
+                    <Txt color="white" size="h6">
+                      승인
+                    </Txt>
+                  </Button>
+                  <Button color="red" className={cn("btn")}>
+                    <Txt size="h6" color="white">
+                      거절
+                    </Txt>
+                  </Button>
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+      <Pagination
+        pagesPerGroup={pagesPerGroup}
+        currentPage={currentPage}
+        itemsPerPage={itemsPerPage}
+        totalItems={totalElements}
+        setPage={setPage}
+      />
+    </div>
+  );
+}

--- a/src/constants/routes/index.ts
+++ b/src/constants/routes/index.ts
@@ -16,5 +16,6 @@ export const ROUTE = {
     EVENT_LIST: "/committee/event-list",
     CREATE_EVENT: "/committee/create-event",
     CREATE_ANNOUNCEMENT: "/committee/create-announcement",
+    APPROVE_WAIT: "/committee/approve-wait",
   },
 };

--- a/src/hooks/committee/approve-wait/useApproveWaitList.ts
+++ b/src/hooks/committee/approve-wait/useApproveWaitList.ts
@@ -1,0 +1,27 @@
+import { useGetPageParams } from "@/hooks/common/useGetPageParams";
+import { useApproveWaitPagination } from "./useApproveWaitPagination";
+import { useGetApproveWaitListQuery } from "@/hooks/tanstack-query/committee/approve-wait/useGetApproveWaitListQuery";
+import { usePostApprove } from "@/hooks/tanstack-query/committee/approve-wait/usePostApprove";
+
+export const useApproveWaitList = () => {
+  const { page: currentPage } = useGetPageParams();
+  const { pagesPerGroup, queryParams, setPage } = useApproveWaitPagination(currentPage);
+
+  const { data, isLoading } = useGetApproveWaitListQuery(queryParams);
+
+  const { onApprove } = usePostApprove();
+
+  const approveWaitList = data?.content || [];
+  const totalElements = data?.totalElements || 0;
+
+  return {
+    approveWaitList,
+    totalElements,
+    currentPage,
+    setPage,
+    itemsPerPage: queryParams.size,
+    pagesPerGroup,
+    isLoading,
+    onApprove,
+  };
+};

--- a/src/hooks/committee/approve-wait/useApproveWaitPagination.ts
+++ b/src/hooks/committee/approve-wait/useApproveWaitPagination.ts
@@ -1,0 +1,27 @@
+import { useRouter, useSearchParams } from "next/navigation";
+
+export const useApproveWaitPagination = (page: number) => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const pagesPerGroup = 5;
+
+  const setPage = (page: number) => {
+    const newParams = new URLSearchParams(searchParams.toString());
+    newParams.set("page", page.toString());
+
+    router.replace(`?${newParams.toString()}`);
+  };
+
+  const queryParams: { page: number; size: number; direction: "asc" | "desc" } = {
+    page: page - 1,
+    size: 4,
+    direction: "desc",
+  };
+
+  return {
+    setPage,
+    pagesPerGroup,
+    queryParams,
+  };
+};

--- a/src/hooks/tanstack-query/committee/approve-wait/useGetApproveWaitListQuery.ts
+++ b/src/hooks/tanstack-query/committee/approve-wait/useGetApproveWaitListQuery.ts
@@ -1,0 +1,16 @@
+import { getApproveWaitList } from "@/apis/committee/approve-wait";
+import { useQuery } from "@tanstack/react-query";
+
+interface ApproveWaitListQueryParams {
+  page: number;
+  size: number;
+  direction: "asc" | "desc";
+}
+
+export const useGetApproveWaitListQuery = ({ page, size, direction }: ApproveWaitListQueryParams) => {
+  return useQuery({
+    queryKey: ["approveWait", page, size, direction],
+    queryFn: () => getApproveWaitList(page, size, direction),
+    enabled: page >= 0,
+  });
+};

--- a/src/hooks/tanstack-query/committee/approve-wait/usePostApprove.ts
+++ b/src/hooks/tanstack-query/committee/approve-wait/usePostApprove.ts
@@ -8,7 +8,7 @@ export const usePostApprove = () => {
   const { mutate } = usePostApproveMutate();
   const queryClient = useQueryClient();
 
-  const eventQueryKeys = useQueryKeys(["approveWait"]);
+  const approveWaitQueryKeys = useQueryKeys(["approveWait"]);
 
   const onApprove = (formData: ApproveWaitRequest) => {
     mutate(formData, {
@@ -16,7 +16,7 @@ export const usePostApprove = () => {
         alert(error.response.data.message || "가입 승인에 실패하였습니다.");
       },
       onSuccess: () => {
-        eventQueryKeys.forEach((queryKey) => {
+        approveWaitQueryKeys.forEach((queryKey) => {
           queryClient.invalidateQueries({ queryKey });
         });
 

--- a/src/hooks/tanstack-query/committee/approve-wait/usePostApprove.ts
+++ b/src/hooks/tanstack-query/committee/approve-wait/usePostApprove.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ApiResponseError } from "@/types/common/api";
+import { useQueryKeys } from "@/hooks/tanstack-query/common/useQueryKeys";
+import { ApproveWaitRequest } from "@/types/committee/approve-wait";
+import { postApproveWait } from "@/apis/committee/approve-wait";
+
+export const usePostApprove = () => {
+  const { mutate } = usePostApproveMutate();
+  const queryClient = useQueryClient();
+
+  const eventQueryKeys = useQueryKeys(["approveWait"]);
+
+  const onApprove = (formData: ApproveWaitRequest) => {
+    mutate(formData, {
+      onError: (error) => {
+        alert(error.response.data.message || "가입 승인에 실패하였습니다.");
+      },
+      onSuccess: () => {
+        eventQueryKeys.forEach((queryKey) => {
+          queryClient.invalidateQueries({ queryKey });
+        });
+
+        alert("가입 승인이 완료되었습니다.");
+      },
+    });
+  };
+  return {
+    onApprove,
+  };
+};
+
+export const usePostApproveMutate = () => {
+  return useMutation<void, ApiResponseError, ApproveWaitRequest>({
+    mutationKey: ["approveWait"],
+    mutationFn: postApproveWait,
+  });
+};

--- a/src/types/committee/approve-wait/index.ts
+++ b/src/types/committee/approve-wait/index.ts
@@ -1,0 +1,3 @@
+export interface ApproveWaitRequest {
+  memberId: number;
+}


### PR DESCRIPTION
### 개요

close #72 

### 작업사항

- 위원회용 페이지 헤더에 승인 대기 페이지로 이동하는 link 태그 추가
- 가입 승인 api, 가입 승인 목록 api 함수 구현
- 가입 승인, 가입 승인 목록 api 관련 tanstack query 구현
- 가입 승인 대기 페이지 구현

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 승인 대기자 목록 페이지가 추가되어, 관리자가 승인 대기 중인 신청자 목록을 확인하고 승인할 수 있습니다.
  - 위원회 헤더에 "승인 대기" 메뉴가 추가되어, MANAGER 권한 사용자가 빠르게 접근할 수 있습니다.
  - 승인 대기 목록에서 페이징 및 정렬 기능이 제공되며, 각 신청자별로 승인 버튼이 제공됩니다.
  - 승인 대기 관련 API 연동 및 데이터 구조가 도입되어 안정적인 데이터 조회 및 처리가 가능합니다.

- **스타일**
  - 승인 대기 페이지 및 헤더에 스켈레톤 로딩, 테이블, 버튼 등 UI 스타일이 추가되었습니다.

- **기타**
  - 사용자 정보에 역할(role) 정보가 추가되어, 권한에 따른 메뉴 노출이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->