### PR TITLE
feat: 공지사항 상세 페이지 구현

### DIFF
--- a/src/apis/committee/announcement/index.ts
+++ b/src/apis/committee/announcement/index.ts
@@ -1,6 +1,6 @@
-import { AnnouncementList } from "@/apis/dtos/committee/announcement";
+import { AnnouncementDetail, AnnouncementList } from "@/apis/dtos/committee/announcement";
 import { https } from "@/apis/instance/https";
-import { CreateAnnouncementFormRequest } from "@/types/committee/announcement";
+import { CreateAnnouncementFormRequest, PutAnnouncementFormRequest } from "@/types/committee/announcement";
 
 export const postCreateAnnouncement = async (formData: CreateAnnouncementFormRequest) => {
   await https.post("announces", formData);
@@ -10,4 +10,20 @@ export const getAnnouncementList = async (page: number, size: number, direction:
   const { data } = await https.get(`announces?page=${page}&size=${size}&direction=${direction}&sort=createdAt`);
 
   return new AnnouncementList(data);
+};
+
+export const getAnnouncement = async (announcementId: string) => {
+  const { data } = await https.get(`announces/${announcementId}`);
+
+  return new AnnouncementDetail(data);
+};
+
+export const putAnnouncement = async ({
+  formData,
+  announcementId,
+}: {
+  formData: PutAnnouncementFormRequest;
+  announcementId: string;
+}) => {
+  await https.put(`announces/${announcementId}`, formData);
 };

--- a/src/apis/dtos/committee/announcement/index.ts
+++ b/src/apis/dtos/committee/announcement/index.ts
@@ -37,3 +37,45 @@ export class AnnouncementList {
     this.isLast = last;
   }
 }
+
+export class AnnouncementDetail {
+  id: string;
+  title: string;
+  content: string;
+  writer: string;
+  createdAt: Date;
+  updatedAt: Date;
+  departments: {
+    id: number;
+    name: string;
+  }[];
+
+  constructor({
+    id,
+    title,
+    content,
+    writer,
+    createdAt,
+    updatedAt,
+    departments,
+  }: {
+    id: string;
+    title: string;
+    content: string;
+    writer: string;
+    createdAt: Date;
+    updatedAt: Date;
+    departments: {
+      id: number;
+      name: string;
+    }[];
+  }) {
+    this.id = id;
+    this.title = title;
+    this.content = content;
+    this.writer = writer;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.departments = departments;
+  }
+}

--- a/src/app/committee/announcement/[announcementId]/page.tsx
+++ b/src/app/committee/announcement/[announcementId]/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import CommitteeHeader from "@/components/common/CommitteeHeader";
+import AnnouncementDetail from "@/components/page/committee/announcement";
+import { Suspense } from "react";
+
+export default function AnnouncementDetailPage() {
+  return (
+    <>
+      <CommitteeHeader />
+      <Suspense>
+        <AnnouncementDetail />
+      </Suspense>
+    </>
+  );
+}

--- a/src/components/common/CommitteeHeader/index.tsx
+++ b/src/components/common/CommitteeHeader/index.tsx
@@ -36,7 +36,7 @@ export default function CommitteeHeader() {
           <Txt
             className={cn("headerTitle")}
             weight="medium"
-            color={path.includes("announcement-list") ? "primary" : "black"}
+            color={path.includes("announcement-list") || path.includes("announcement") ? "primary" : "black"}
           >
             공지사항
           </Txt>

--- a/src/components/page/committee/announcement/AnnouncementDetailInfoForm/index.module.scss
+++ b/src/components/page/committee/announcement/AnnouncementDetailInfoForm/index.module.scss
@@ -1,0 +1,51 @@
+.header {
+  background-color: #f9f9f9;
+  padding: 2rem;
+  border-radius: 1rem 1rem 0 0;
+  border: 0.1rem solid #c1c1c1;
+}
+
+.contentContainer {
+  padding: 2rem;
+  border: 0.1rem solid #c1c1c1;
+  border-top: 0rem;
+  @include flexSort(column, null, null, 2rem);
+  border-radius: 0 0 1rem 1rem;
+}
+
+.textarea {
+  height: 20rem;
+}
+
+.participationDepartmentSelectorContainer {
+  @include flexSort(row, space-between, center, 2rem);
+}
+
+.selectDepartmentContainer {
+  @include flexSort(column, null, null, 1rem);
+}
+
+.selectedDepartmentContainer {
+  @include flexSort(column, null, null, 1rem);
+}
+
+.selectedDepartment {
+  @include flexSort(row, center, center, 1rem);
+  padding: 1rem 2rem;
+  border-radius: 1rem;
+  background-color: #f9f9f9;
+  border: 0.1rem solid #c1c1c1;
+  width: fit-content;
+}
+
+.deleteDepartmentBtn {
+  width: fit-content;
+  padding: 0.5rem 1rem;
+  margin-left: auto;
+}
+
+.announcementBtn {
+  width: fit-content;
+  padding: 1.5rem;
+  margin-left: auto;
+}

--- a/src/components/page/committee/announcement/AnnouncementDetailInfoForm/index.tsx
+++ b/src/components/page/committee/announcement/AnnouncementDetailInfoForm/index.tsx
@@ -1,0 +1,132 @@
+import Txt from "@/components/design-system/Txt";
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import TextInput from "@/components/common/TextInput";
+import "react-datepicker/dist/react-datepicker.css";
+import Button from "@/components/design-system/Button";
+import { Selector } from "@/components/common/Selector";
+import { LabeledTextarea } from "@/components/common/LabeledTextarea";
+import { AnnouncementDetailForm } from "@/types/committee/announcement";
+
+const cn = classNames.bind(styles);
+
+interface AnnouncementDetailFormProps {
+  formData: AnnouncementDetailForm;
+  setFormData: (formData: AnnouncementDetailForm) => void;
+  organizations: {
+    id: number;
+    value: string;
+  }[];
+  departments: {
+    id: number;
+    value: string;
+  }[];
+  onDeleteDepartment: (id: number) => void;
+  onSelectDepartment: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  onSelectOrganizations: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  onPutAnnouncement: () => void;
+  isPutMode: boolean;
+  onClickEditButton: () => void;
+}
+
+export default function AnnouncementDetailInfoForm({
+  formData,
+  setFormData,
+  organizations,
+  departments,
+  onDeleteDepartment,
+  onSelectOrganizations,
+  onSelectDepartment,
+  onPutAnnouncement,
+  isPutMode,
+  onClickEditButton,
+}: AnnouncementDetailFormProps) {
+  return (
+    <div>
+      <header className={cn("header")}>
+        <Txt weight="medium">공지사항</Txt>
+      </header>
+      <div className={cn("contentContainer")}>
+        <TextInput
+          id="title"
+          onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+          label="제목"
+          type="text"
+          value={formData.title}
+          placeholder="공지사항 제목을 입력해주세요."
+          readOnly={!isPutMode}
+        />
+        <LabeledTextarea
+          id="content"
+          onChange={(e) => setFormData({ ...formData, content: e.target.value })}
+          label="내용"
+          value={formData.content}
+          placeholder="공지사항 내용을 입력해주세요."
+          labeledTextareaContainerClassName={cn("textarea")}
+          readOnly={!isPutMode}
+        />
+        <Txt size="h5" weight="medium">
+          공지사항 참여 학과
+        </Txt>
+        {isPutMode && (
+          <div className={cn("participationDepartmentSelectorContainer")}>
+            <Selector
+              label="소속"
+              onChange={onSelectOrganizations}
+              options={organizations}
+              value={formData.affiliation.value}
+              id="affiliation"
+            />
+            <Selector
+              label="학과"
+              onChange={onSelectDepartment}
+              options={departments}
+              value={departments[0].value}
+              id="department"
+            />
+          </div>
+        )}
+        <div className={cn("selectDepartmentContainer")}>
+          {isPutMode && (
+            <Txt size="h5" weight="medium">
+              선택한 참여 학과
+            </Txt>
+          )}
+          <div className={cn("selectedDepartmentContainer")}>
+            {formData.participationDepartmentIds.map((department) => (
+              <div key={department.id} className={cn("selectedDepartment")}>
+                <Txt size="small" weight="medium">
+                  {department.value}
+                </Txt>
+                {isPutMode && (
+                  <Button
+                    className={cn("deleteDepartmentBtn")}
+                    color="red"
+                    onClick={() => onDeleteDepartment(department.id)}
+                  >
+                    <Txt size="small" color="white">
+                      삭제
+                    </Txt>
+                  </Button>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+        {isPutMode ? (
+          <Button type="submit" className={cn("announcementBtn")} color="primary" onClick={onPutAnnouncement}>
+            <Txt size="h6" color="white">
+              수정 완료
+            </Txt>
+          </Button>
+        ) : (
+          <Button type="submit" className={cn("announcementBtn")} color="primary" onClick={onClickEditButton}>
+            <Txt size="h6" color="white">
+              수정하기
+            </Txt>
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/page/committee/announcement/index.module.scss
+++ b/src/components/page/committee/announcement/index.module.scss
@@ -1,0 +1,4 @@
+.container {
+  padding: 4rem;
+  @include flexSort(column, null, null, 3rem);
+}

--- a/src/components/page/committee/announcement/index.tsx
+++ b/src/components/page/committee/announcement/index.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import Txt from "@/components/design-system/Txt";
+import { useAnnouncementForm } from "@/hooks/committee/announcement/useAnnouncementForm";
+import AnnouncementDetailForm from "./AnnouncementDetailInfoForm";
+
+const cn = classNames.bind(styles);
+
+export default function AnnouncementDetail() {
+  const {
+    formData,
+    setFormData,
+    organizations,
+    departments,
+    onDeleteDepartment,
+    onSelectDepartment,
+    onSelectOrganizations,
+    onPutAnnouncement,
+    isPutMode,
+    onClickEditButton,
+  } = useAnnouncementForm();
+
+  return (
+    <div className={cn("container")}>
+      <Txt color="primary" size="h3" weight="medium">
+        공지사항
+      </Txt>
+      <AnnouncementDetailForm
+        formData={formData}
+        setFormData={setFormData}
+        organizations={organizations}
+        departments={departments}
+        onDeleteDepartment={onDeleteDepartment}
+        onSelectDepartment={onSelectDepartment}
+        onSelectOrganizations={onSelectOrganizations}
+        onPutAnnouncement={onPutAnnouncement}
+        isPutMode={isPutMode}
+        onClickEditButton={onClickEditButton}
+      />
+    </div>
+  );
+}

--- a/src/constants/routes/index.ts
+++ b/src/constants/routes/index.ts
@@ -13,6 +13,7 @@ export const ROUTE = {
     SIGN_UP: "/committee/sign-up",
     APPLY_LIST: "/committee/apply-list",
     ANNOUNCEMENT_LIST: "/committee/announcement-list",
+    ANNOUNCEMENT: "/committee/announcement",
     EVENT_LIST: "/committee/event-list",
     CREATE_EVENT: "/committee/create-event",
     CREATE_ANNOUNCEMENT: "/committee/create-announcement",

--- a/src/hooks/committee/announcement/useAnnouncementForm.ts
+++ b/src/hooks/committee/announcement/useAnnouncementForm.ts
@@ -1,0 +1,140 @@
+import { useDepartmentsQuery, useOrganizationsQuery } from "@/hooks/tanstack-query/common/sign-up";
+import { ChangeEvent, useEffect, useState } from "react";
+import { AnnouncementDetailForm } from "@/types/committee/announcement";
+import { createAnnouncementValidator } from "@/functions/validator/createAnnouncementValidator";
+import { CREATE_ANNOUNCEMENT_VALIDATION } from "@/constants/validation/createAnnouncement";
+import { useGetAnnouncement } from "@/hooks/tanstack-query/committee/announcement/useGetAnnouncement";
+import { useGetAnnouncementId } from "@/hooks/common/useGetPageAnnouncementId";
+import { usePutAnnouncement } from "@/hooks/tanstack-query/committee/announcement/usePutAnnouncement";
+
+export const useAnnouncementForm = () => {
+  const { announcementId } = useGetAnnouncementId();
+
+  const { data } = useGetAnnouncement(announcementId);
+
+  const [isPutMode, setIsPutMode] = useState(false);
+
+  const [formData, setFormData] = useState<AnnouncementDetailForm>({
+    title: "",
+    content: "",
+    departments: [],
+    createdAt: null,
+    updatedAt: null,
+    writer: "",
+    affiliation: {
+      id: 0,
+      value: "값을 선택해주세요.",
+    },
+    participationDepartmentIds: [],
+  });
+
+  const { onPutAnnouncement: putAnnouncement } = usePutAnnouncement(announcementId);
+
+  let organizations = useOrganizationsQuery("학생회");
+
+  if (!organizations) {
+    organizations = [{ id: 0, value: "값을 선택해주세요." }];
+  } else {
+    organizations = [{ id: 0, value: "값을 선택해주세요." }, ...organizations];
+  }
+
+  let departments = useDepartmentsQuery(formData.affiliation.id);
+
+  if (!departments) {
+    departments = [{ id: 0, value: "값을 선택해주세요." }];
+  }
+
+  useEffect(() => {
+    if (data) {
+      setFormData({
+        title: data.title,
+        content: data.content,
+        departments: data.departments,
+        createdAt: data.createdAt,
+        updatedAt: data.updatedAt,
+        writer: data.writer,
+        affiliation: {
+          id: 0,
+          value: "값을 선택해주세요.",
+        },
+        participationDepartmentIds: data.departments.map((department) => ({
+          id: department.id,
+          value: department.name,
+        })),
+      });
+    }
+  }, [data]);
+
+  const onSelectOrganizations = (e: ChangeEvent<HTMLSelectElement>) => {
+    const { value } = e.target;
+    const selectedId = Number(e.target.options[e.target.selectedIndex].getAttribute("data-id"));
+
+    setFormData((prev) => ({
+      ...prev,
+      affiliation: {
+        id: selectedId,
+        value: value,
+      },
+    }));
+  };
+
+  const onSelectDepartment = (e: ChangeEvent<HTMLSelectElement>) => {
+    const { value } = e.target;
+    const selectedId = Number(e.target.options[e.target.selectedIndex].getAttribute("data-id"));
+
+    const isDuplicate = formData.participationDepartmentIds.some((department) => department.id === selectedId);
+
+    if (isDuplicate) {
+      alert(CREATE_ANNOUNCEMENT_VALIDATION.department.duplicate);
+      return;
+    }
+
+    setFormData((prev) => ({
+      ...prev,
+      participationDepartmentIds: [
+        ...prev.participationDepartmentIds,
+        {
+          id: selectedId,
+          value: value,
+        },
+      ],
+    }));
+  };
+
+  const onDeleteDepartment = (id: number) => {
+    setFormData((prev) => ({
+      ...prev,
+      participationDepartmentIds: prev.participationDepartmentIds.filter((department) => department.id !== id),
+    }));
+  };
+
+  const onPutAnnouncement = () => {
+    if (!createAnnouncementValidator(formData)) {
+      return;
+    }
+
+    putAnnouncement({
+      title: formData.title,
+      content: formData.content,
+      participationDepartmentIds: formData.participationDepartmentIds.map((department) => department.id),
+    });
+    setIsPutMode(false);
+  };
+
+  const onClickEditButton = () => {
+    setIsPutMode(true);
+  };
+
+  return {
+    formData,
+    setFormData,
+    onPutAnnouncement,
+    organizations,
+    departments,
+    onSelectDepartment,
+    onDeleteDepartment,
+    onSelectOrganizations,
+    isPutMode,
+    onClickEditButton,
+  };
+};

--- a/src/hooks/committee/announcement/useAnnouncementList.ts
+++ b/src/hooks/committee/announcement/useAnnouncementList.ts
@@ -15,7 +15,7 @@ export const useAnnouncementList = () => {
   const totalElements = data?.totalElements || 0;
 
   const onAnnouncementClick = (eventId: string) => {
-    router.push(`${ROUTE.COMMITTEE.ANNOUNCEMENT_LIST}/${eventId}`);
+    router.push(`${ROUTE.COMMITTEE.ANNOUNCEMENT}/${eventId}`);
   };
 
   return {

--- a/src/hooks/common/useGetPageAnnouncementId.ts
+++ b/src/hooks/common/useGetPageAnnouncementId.ts
@@ -1,0 +1,10 @@
+import { usePathname } from "next/navigation";
+
+export const useGetAnnouncementId = () => {
+  const pathName = usePathname();
+  const announcementId = pathName.split("/").at(-1) || "";
+
+  return {
+    announcementId,
+  };
+};

--- a/src/hooks/tanstack-query/committee/announcement/useGetAnnouncement.ts
+++ b/src/hooks/tanstack-query/committee/announcement/useGetAnnouncement.ts
@@ -1,0 +1,10 @@
+import { getAnnouncement } from "@/apis/committee/announcement";
+import { useQuery } from "@tanstack/react-query";
+
+export const useGetAnnouncement = (announcementId: string) => {
+  return useQuery({
+    queryKey: ["announcement", announcementId],
+    queryFn: () => getAnnouncement(announcementId),
+    enabled: !!announcementId,
+  });
+};

--- a/src/hooks/tanstack-query/committee/announcement/usePutAnnouncement.ts
+++ b/src/hooks/tanstack-query/committee/announcement/usePutAnnouncement.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ApiResponseError } from "@/types/common/api";
+import { PutAnnouncementFormRequest } from "@/types/committee/announcement";
+import { putAnnouncement } from "@/apis/committee/announcement";
+
+export const usePutAnnouncement = (announcementId: string) => {
+  const { mutate } = usePutAnnouncementMutate();
+  const queryClient = useQueryClient();
+
+  const onPutAnnouncement = (formData: PutAnnouncementFormRequest) => {
+    mutate(
+      { formData, announcementId },
+      {
+        onError: (error) => {
+          alert(error.response.data.message || "공지사항 수정에 실패하였습니다.");
+        },
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: ["announcement", announcementId] });
+
+          alert("공지사항 수정에 성공하셨습니다.");
+        },
+      },
+    );
+  };
+  return {
+    onPutAnnouncement,
+  };
+};
+
+export const usePutAnnouncementMutate = () => {
+  return useMutation<void, ApiResponseError, { formData: PutAnnouncementFormRequest; announcementId: string }>({
+    mutationKey: ["putAnnouncement"],
+    mutationFn: putAnnouncement,
+  });
+};

--- a/src/types/committee/announcement/index.ts
+++ b/src/types/committee/announcement/index.ts
@@ -16,3 +16,26 @@ export interface CreateAnnouncementFormRequest {
   content: string;
   participationDepartmentIds: number[];
 }
+
+export interface AnnouncementDetailForm {
+  title: string;
+  content: string;
+  departments: { id: number; name: string }[];
+  createdAt: Date | null;
+  updatedAt: Date | null;
+  writer: string;
+  affiliation: {
+    id: number;
+    value: string;
+  };
+  participationDepartmentIds: {
+    id: number;
+    value: string;
+  }[];
+}
+
+export interface PutAnnouncementFormRequest {
+  title: string;
+  content: string;
+  participationDepartmentIds: number[];
+}


### PR DESCRIPTION
### 개요

close #78 

### 작업사항

- 공지사항 상세 페이지 구현
- 공지사항 상세 페이지 경로 변경
- 공지사항 get, put api 함수 구현
- 공지사항 get, put api 관련 tanstack query 훅 구현
- 공지사항 상세 페이지에서 사용하는 useAnnouncementForm 훅 구현

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 공지사항 상세 페이지가 추가되어 개별 공지사항의 상세 정보 확인 및 수정이 가능합니다.
  - 공지사항 상세 정보에 참여 부서, 수정일, 작성자 등 추가 정보가 표시됩니다.
  - 공지사항 수정 시 참여 부서 선택 및 삭제, 내용 편집이 가능합니다.

- **스타일**
  - 공지사항 상세 및 수정 폼에 대한 새로운 스타일이 적용되었습니다.
  - 공지사항 관련 페이지의 레이아웃과 버튼, 입력창 등의 UI가 개선되었습니다.

- **버그 수정**
  - 공지사항 메뉴의 강조 색상이 경로에 따라 더 넓게 적용되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->