### PR TITLE
refactor: 학과 정보 페이지 수정

### DIFF
--- a/src/apis/student/department-info/index.ts
+++ b/src/apis/student/department-info/index.ts
@@ -1,11 +1,8 @@
-import { MyEvent } from "@/apis/dtos/student/event";
 import { https } from "@/apis/instance/https";
-import { MyEventType } from "@/types/student/department-info";
+import { MyEventList } from "@/types/student/department-info";
 
 export const getMyEvent = async () => {
   const { data } = await https.get("events/me");
 
-  const myEventList = data.map((event: MyEventType) => new MyEvent(event));
-
-  return myEventList;
+  return new MyEventList(data);
 };

--- a/src/apis/student/department-info/index.ts
+++ b/src/apis/student/department-info/index.ts
@@ -1,8 +1,14 @@
 import { https } from "@/apis/instance/https";
-import { MyEventList } from "@/types/student/department-info";
+import { MyAnnouncementList, MyEventList } from "@/types/student/department-info";
 
 export const getMyEvent = async () => {
   const { data } = await https.get("events/me");
 
   return new MyEventList(data);
+};
+
+export const getMyAnnouncement = async () => {
+  const { data } = await https.get("announces/me?page=0&size=1&direction=desc&sort=createdAt");
+
+  return new MyAnnouncementList(data);
 };

--- a/src/apis/student/department-info/index.ts
+++ b/src/apis/student/department-info/index.ts
@@ -1,8 +1,9 @@
 import { https } from "@/apis/instance/https";
 import { MyAnnouncementList, MyEventList } from "@/types/student/department-info";
 
+// Todo : 매직 넘버 제거
 export const getMyEvent = async () => {
-  const { data } = await https.get("events/me");
+  const { data } = await https.get("events/me?page=0&size=100&direction=desc&sort=createdAt");
 
   return new MyEventList(data);
 };

--- a/src/components/page/student/DepartmentInfo/DepartmentInfoAnnouncement/index.module.scss
+++ b/src/components/page/student/DepartmentInfo/DepartmentInfoAnnouncement/index.module.scss
@@ -1,3 +1,7 @@
+.skeleton {
+  height: 15rem;
+}
+
 .container {
   @include flexSort(column, null, null, 1.5rem);
 }

--- a/src/components/page/student/DepartmentInfo/DepartmentInfoAnnouncement/index.tsx
+++ b/src/components/page/student/DepartmentInfo/DepartmentInfoAnnouncement/index.tsx
@@ -1,13 +1,25 @@
+"use client";
+
 import classNames from "classnames/bind";
 import styles from "./index.module.scss";
 import Link from "next/link";
 import { ROUTE } from "@/constants/routes";
 import Txt from "@/components/design-system/Txt";
+import { useGetMyAnnouncement } from "@/hooks/tanstack-query/student/department-info/useGetMyAnnouncement";
+import Skeleton from "@/components/common/Skeleton";
 
 const cn = classNames.bind(styles);
 
 export default function DepartmentInfoAnnouncement() {
-  const announcementId = 1;
+  const { data, isPending, isError } = useGetMyAnnouncement();
+
+  if (isPending) {
+    return <Skeleton className={cn("skeleton")} />;
+  }
+
+  if (isError) {
+    return null;
+  }
 
   return (
     <div className={cn("container")}>
@@ -15,11 +27,10 @@ export default function DepartmentInfoAnnouncement() {
         공지사항
       </Txt>
       <div className={cn("announcementContainer")}>
-        <Link href={`${ROUTE.STUDENT.DEPARTMENT_INFO_ANNOUNCEMENT}/${announcementId}`}>
-          <Txt
-            className={cn("announcement")}
-            size="h4"
-          >{`제목아아아아ㅏ아앙아ㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅇㅇㅇㅇㅇㅇㅇㅇ`}</Txt>
+        <Link href={`${ROUTE.STUDENT.DEPARTMENT_INFO_ANNOUNCEMENT}/${data.content[0].id}`}>
+          <Txt className={cn("announcement")} size="h4">
+            {data.content[0].title}
+          </Txt>
         </Link>
       </div>
       <div className={cn("moreLinkContainer")}>

--- a/src/components/page/student/DepartmentInfo/DepartmentInfoApplyLocker/index.tsx
+++ b/src/components/page/student/DepartmentInfo/DepartmentInfoApplyLocker/index.tsx
@@ -12,7 +12,7 @@ const cn = classNames.bind(styles);
 
 export default function DepartmentInfoApplyLocker() {
   const { data, isError, isPending } = useGetMyEvent();
-  const OPTIONS: EmblaOptionsType = { loop: true };
+  const OPTIONS: EmblaOptionsType = { containScroll: false };
 
   if (isPending) {
     return <Skeleton className={cn("skeleton")} />;
@@ -27,7 +27,7 @@ export default function DepartmentInfoApplyLocker() {
       <Txt color="secondary" weight="bold" size="h3">
         사물함 신청
       </Txt>
-      <MyLockerEventCarousel myEventList={data} options={OPTIONS} />
+      <MyLockerEventCarousel myEventList={data.content} options={OPTIONS} />
     </div>
   );
 }

--- a/src/hooks/tanstack-query/student/department-info/useGetMyAnnouncement.ts
+++ b/src/hooks/tanstack-query/student/department-info/useGetMyAnnouncement.ts
@@ -1,0 +1,9 @@
+import { getMyAnnouncement } from "@/apis/student/department-info";
+import { useQuery } from "@tanstack/react-query";
+
+export const useGetMyAnnouncement = () => {
+  return useQuery({
+    queryKey: ["myAnnouncement"],
+    queryFn: () => getMyAnnouncement(),
+  });
+};

--- a/src/hooks/tanstack-query/student/department-info/useGetMyEvent.ts
+++ b/src/hooks/tanstack-query/student/department-info/useGetMyEvent.ts
@@ -1,9 +1,8 @@
 import { getMyEvent } from "@/apis/student/department-info";
-import { MyEventType } from "@/types/student/department-info";
 import { useQuery } from "@tanstack/react-query";
 
 export const useGetMyEvent = () => {
-  return useQuery<MyEventType[]>({
+  return useQuery({
     queryKey: ["myEvent"],
     queryFn: () => getMyEvent(),
   });

--- a/src/types/student/department-info/index.ts
+++ b/src/types/student/department-info/index.ts
@@ -6,3 +6,15 @@ export interface MyEventType {
   endAt: Date;
   availableLockerCount: number;
 }
+
+export class MyEventList {
+  content: MyEventType[];
+  totalElements: number;
+  isLast: boolean;
+
+  constructor({ content, totalElements, last }: { content: MyEventType[]; totalElements: number; last: boolean }) {
+    this.content = content;
+    this.totalElements = totalElements;
+    this.isLast = last;
+  }
+}

--- a/src/types/student/department-info/index.ts
+++ b/src/types/student/department-info/index.ts
@@ -18,3 +18,30 @@ export class MyEventList {
     this.isLast = last;
   }
 }
+
+export interface MyAnnouncementType {
+  id: string;
+  title: string;
+  writer: string;
+  createdAt: Date;
+}
+
+export class MyAnnouncementList {
+  content: MyAnnouncementType[];
+  totalElements: number;
+  isLast: boolean;
+
+  constructor({
+    content,
+    totalElements,
+    last,
+  }: {
+    content: MyAnnouncementType[];
+    totalElements: number;
+    last: boolean;
+  }) {
+    this.content = content;
+    this.totalElements = totalElements;
+    this.isLast = last;
+  }
+}


### PR DESCRIPTION
### 개요

close #83 

### 작업사항

- 나의 소속 학과에 관련된 공지사항 api 연결
- 이벤트 ui 캐러셀 부분 수정 (첫 렌더링 시 왼쪽으로 넘어가는 부분은 안보이게 수정)
- 이벤트 get api 수정 (페이지네이션으로 바뀜)

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 최근 공지사항을 불러오는 기능이 추가되었습니다.
	- 공지사항 데이터를 쉽게 사용할 수 있는 React 훅이 도입되었습니다.
- **버그 수정**
	- 사물함 이벤트 캐러셀의 데이터 전달 방식이 개선되어 더 정확한 정보가 표시됩니다.
- **리팩터링**
	- 이벤트 및 공지사항 데이터 구조가 일관성 있게 개선되었습니다.
	- 공지사항 및 이벤트 조회 시 쿼리 파라미터가 명확하게 적용되었습니다.
- **스타일**
	- 공지사항 로딩 시 표시되는 스켈레톤 UI가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->