### PR TITLE
feat: 나의 학과에 해당하는 공지사항 목록 페이지 구현

### DIFF
--- a/src/apis/dtos/student/announcement/index.ts
+++ b/src/apis/dtos/student/announcement/index.ts
@@ -1,0 +1,36 @@
+export class MyAnnouncement {
+  id: number;
+  title: string;
+  writer: string;
+  createdAt: Date;
+
+  constructor({
+    id,
+    title,
+    writer,
+    createdAt,
+  }: {
+    id: number;
+    title: string;
+    content: string;
+    writer: string;
+    createdAt: Date;
+  }) {
+    this.id = id;
+    this.title = title;
+    this.writer = writer;
+    this.createdAt = createdAt;
+  }
+}
+
+export class MyAnnouncementList {
+  content: MyAnnouncement[];
+  totalElements: number;
+  isLast: boolean;
+
+  constructor({ content, totalElements, last }: { content: MyAnnouncement[]; totalElements: number; last: boolean }) {
+    this.content = content;
+    this.totalElements = totalElements;
+    this.isLast = last;
+  }
+}

--- a/src/apis/student/announcement/index.ts
+++ b/src/apis/student/announcement/index.ts
@@ -1,0 +1,8 @@
+import { MyAnnouncementList } from "@/apis/dtos/student/announcement";
+import { https } from "@/apis/instance/https";
+
+export const getMyAnnouncementList = async (page: number, size: number, direction: "asc" | "desc") => {
+  const { data } = await https.get(`announces/me?page=${page}&size=${size}&direction=${direction}&sort=createdAt`);
+
+  return new MyAnnouncementList(data);
+};

--- a/src/app/student/my-announcement-list/page.tsx
+++ b/src/app/student/my-announcement-list/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import MyAnnouncementList from "@/components/page/student/my-announcement-list";
+import { Suspense } from "react";
+
+export default function MyAnnouncementListPage() {
+  return (
+    <>
+      <Suspense>
+        <MyAnnouncementList />
+      </Suspense>
+    </>
+  );
+}

--- a/src/components/page/student/DepartmentInfo/DepartmentInfoAnnouncement/index.tsx
+++ b/src/components/page/student/DepartmentInfo/DepartmentInfoAnnouncement/index.tsx
@@ -34,7 +34,7 @@ export default function DepartmentInfoAnnouncement() {
         </Link>
       </div>
       <div className={cn("moreLinkContainer")}>
-        <Link href={ROUTE.STUDENT.DEPARTMENT_INFO_ANNOUNCEMENT_LIST}>
+        <Link href={ROUTE.STUDENT.MY_ANNOUNCEMENT_LIST}>
           <Txt size="tiny" className={cn("moreLink")}>
             더보기
           </Txt>

--- a/src/components/page/student/DepartmentInfo/DepartmentInfoAnnouncement/index.tsx
+++ b/src/components/page/student/DepartmentInfo/DepartmentInfoAnnouncement/index.tsx
@@ -27,7 +27,7 @@ export default function DepartmentInfoAnnouncement() {
         공지사항
       </Txt>
       <div className={cn("announcementContainer")}>
-        <Link href={`${ROUTE.STUDENT.DEPARTMENT_INFO_ANNOUNCEMENT}/${data.content[0].id}`}>
+        <Link href={`${ROUTE.STUDENT.MY_ANNOUNCEMENT}/${data.content[0].id}`}>
           <Txt className={cn("announcement")} size="h4">
             {data.content[0].title}
           </Txt>

--- a/src/components/page/student/my-announcement-list/index.module.scss
+++ b/src/components/page/student/my-announcement-list/index.module.scss
@@ -1,0 +1,61 @@
+.skeleton {
+  width: 100%;
+  height: 30rem;
+}
+
+.container {
+  padding: 4rem;
+  @include flexSort(column, null, null, 3rem);
+}
+
+.tableHeaderContainer {
+  background-color: $primary;
+  border-left: 0.2rem solid $primary;
+  border-right: 0.2rem solid $primary;
+}
+
+.tableHeader {
+  padding: 2rem;
+
+  @include mobile {
+    padding: 1rem;
+  }
+}
+
+.tableHeaderTitle {
+  @include mobile {
+    font-size: 1.7rem !important;
+  }
+}
+
+.tr {
+  border-bottom: 0.2rem solid $primary;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f0f0f0;
+  }
+}
+
+.tableBodyTitle {
+  @include mobile {
+    font-size: 1.5rem !important;
+  }
+}
+
+.tableData {
+  text-align: center;
+  padding: 2rem;
+
+  &:first-child {
+    border-left: 0.2rem solid $primary;
+  }
+
+  &:last-child {
+    border-right: 0.2rem solid $primary;
+  }
+
+  @include mobile {
+    padding: 1rem;
+  }
+}

--- a/src/components/page/student/my-announcement-list/index.tsx
+++ b/src/components/page/student/my-announcement-list/index.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import Txt from "@/components/design-system/Txt";
+import Pagination from "@/components/common/Pagination";
+import { formatToKoreanTime } from "@/utils/date";
+import Skeleton from "@/components/common/Skeleton";
+import { useMyAnnouncementList } from "@/hooks/student/announcement/useMyAnnouncementList";
+
+const cn = classNames.bind(styles);
+
+export default function MyAnnouncementList() {
+  const {
+    myAnnouncementList,
+    totalElements,
+    currentPage,
+    setPage,
+    itemsPerPage,
+    pagesPerGroup,
+    onAnnouncementClick,
+    isLoading,
+  } = useMyAnnouncementList();
+
+  return (
+    <div className={cn("container")}>
+      <Txt color="primary" size="h3" weight="medium">
+        공지사항 목록
+      </Txt>
+      <table>
+        <thead className={cn("tableHeaderContainer")}>
+          <tr>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium" className={cn("tableHeaderTitle")}>
+                제목
+              </Txt>
+            </th>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium" className={cn("tableHeaderTitle")}>
+                작성자
+              </Txt>
+            </th>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium" className={cn("tableHeaderTitle")}>
+                작성일
+              </Txt>
+            </th>
+          </tr>
+        </thead>
+        {isLoading ? (
+          <tbody>
+            <tr>
+              <td colSpan={3}>
+                <Skeleton className={cn("skeleton")} />
+              </td>
+            </tr>
+          </tbody>
+        ) : (
+          <tbody>
+            {myAnnouncementList.map((myAnnouncement) => (
+              <tr className={cn("tr")} key={myAnnouncement.id} onClick={() => onAnnouncementClick(myAnnouncement.id)}>
+                <td className={cn("tableData")}>
+                  <Txt size="h6" className={cn("tableBodyTitle")}>
+                    {myAnnouncement.title}
+                  </Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6" className={cn("tableBodyTitle")}>
+                    {myAnnouncement.writer}
+                  </Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt
+                    size="h6"
+                    className={cn("tableBodyTitle")}
+                  >{`${formatToKoreanTime(myAnnouncement.createdAt)}`}</Txt>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        )}
+      </table>
+      <Pagination
+        pagesPerGroup={pagesPerGroup}
+        currentPage={currentPage}
+        itemsPerPage={itemsPerPage}
+        totalItems={totalElements}
+        setPage={setPage}
+      />
+    </div>
+  );
+}

--- a/src/constants/routes/index.ts
+++ b/src/constants/routes/index.ts
@@ -4,7 +4,7 @@ export const ROUTE = {
     SIGN_UP: "/student/sign-up",
     DEPARTMENT_INFO: "/student/department-info",
     ENTER_EMAIL: "/student/enter-email",
-    DEPARTMENT_INFO_ANNOUNCEMENT: "/student/department-info/announcement",
+    MY_ANNOUNCEMENT: "/student/my-announcement",
     MY_ANNOUNCEMENT_LIST: "/student/my-announcement-list",
     APPLY_LOCKER: "/student/apply-locker",
   },

--- a/src/constants/routes/index.ts
+++ b/src/constants/routes/index.ts
@@ -5,7 +5,7 @@ export const ROUTE = {
     DEPARTMENT_INFO: "/student/department-info",
     ENTER_EMAIL: "/student/enter-email",
     DEPARTMENT_INFO_ANNOUNCEMENT: "/student/department-info/announcement",
-    DEPARTMENT_INFO_ANNOUNCEMENT_LIST: "/student/department-info/announcement/list",
+    MY_ANNOUNCEMENT_LIST: "/student/my-announcement-list",
     APPLY_LOCKER: "/student/apply-locker",
   },
   COMMITTEE: {

--- a/src/hooks/student/announcement/useMyAnnouncementList.ts
+++ b/src/hooks/student/announcement/useMyAnnouncementList.ts
@@ -1,0 +1,31 @@
+import { useGetPageParams } from "@/hooks/common/useGetPageParams";
+import { useRouter } from "next/navigation";
+import { ROUTE } from "@/constants/routes";
+import { useMyAnnouncementPagination } from "@/hooks/student/announcement/useMyAnnouncementPagination";
+import { useGetMyAnnouncementListQuery } from "@/hooks/tanstack-query/student/announcement/useGetMyAnnouncementListQuery";
+
+export const useMyAnnouncementList = () => {
+  const router = useRouter();
+  const { page: currentPage } = useGetPageParams();
+  const { pagesPerGroup, queryParams, setPage } = useMyAnnouncementPagination(currentPage);
+
+  const { data, isLoading } = useGetMyAnnouncementListQuery(queryParams);
+
+  const myAnnouncementList = data?.content || [];
+  const totalElements = data?.totalElements || 0;
+
+  const onAnnouncementClick = (id: number) => {
+    router.push(`${ROUTE.STUDENT.MY_ANNOUNCEMENT}/${id}`);
+  };
+
+  return {
+    myAnnouncementList,
+    totalElements,
+    currentPage,
+    setPage,
+    itemsPerPage: queryParams.size,
+    pagesPerGroup,
+    onAnnouncementClick,
+    isLoading,
+  };
+};

--- a/src/hooks/student/announcement/useMyAnnouncementPagination.ts
+++ b/src/hooks/student/announcement/useMyAnnouncementPagination.ts
@@ -1,0 +1,27 @@
+import { useRouter, useSearchParams } from "next/navigation";
+
+export const useMyAnnouncementPagination = (page: number) => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const pagesPerGroup = 5;
+
+  const setPage = (page: number) => {
+    const newParams = new URLSearchParams(searchParams.toString());
+    newParams.set("page", page.toString());
+
+    router.replace(`?${newParams.toString()}`);
+  };
+
+  const queryParams: { page: number; size: number; direction: "asc" | "desc" } = {
+    page: page - 1,
+    size: 4,
+    direction: "desc",
+  };
+
+  return {
+    setPage,
+    pagesPerGroup,
+    queryParams,
+  };
+};

--- a/src/hooks/tanstack-query/student/announcement/useGetMyAnnouncementListQuery.ts
+++ b/src/hooks/tanstack-query/student/announcement/useGetMyAnnouncementListQuery.ts
@@ -1,0 +1,16 @@
+import { getMyAnnouncementList } from "@/apis/student/announcement";
+import { useQuery } from "@tanstack/react-query";
+
+interface MyAnnouncementListQueryParams {
+  page: number;
+  size: number;
+  direction: "asc" | "desc";
+}
+
+export const useGetMyAnnouncementListQuery = ({ page, size, direction }: MyAnnouncementListQueryParams) => {
+  return useQuery({
+    queryKey: ["myAnnouncementList", page, size, direction],
+    queryFn: () => getMyAnnouncementList(page, size, direction),
+    enabled: page >= 0,
+  });
+};


### PR DESCRIPTION
### 개요

close #85 

### 작업사항

- 나의 학과에 해당하는 공지사항 목록 페이지 구현
- 나의 학과에 해당하는 공지사항 목록을 불러오는 api 함수 구현
- 나의 학과에 해당하는 공지사항 목록을 불러오는 api 함수 관련 tanstack query 훅 구현
- 나의 학과에 해당하는 공지사항 목록 페이지에서 사용하는 커스텀 훅 구현

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 학생용 공지사항 목록 페이지가 추가되었습니다.
    - 공지사항 목록에서 제목, 작성자, 작성일을 확인할 수 있습니다.
    - 페이지네이션을 통해 여러 페이지의 공지사항을 탐색할 수 있습니다.
    - 공지사항 행 클릭 시 상세 페이지로 이동합니다.
    - 학생 공지사항 목록 조회 API와 관련 훅이 도입되었습니다.
    - 공지사항 목록 페이지의 클라이언트 컴포넌트가 추가되었습니다.

- **스타일**
    - 공지사항 목록 페이지에 대한 전용 스타일이 적용되었습니다.

- **버그 수정**
    - "더보기" 링크가 학생용 공지사항 목록 페이지로 이동하도록 수정되었습니다.

- **경로 변경**
    - 학생 공지사항 관련 경로가 새로운 URL로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->