### PR TITLE
feat: 나의 학과에 해당하는 공지사항 상세 페이지 구현

### DIFF
--- a/src/apis/dtos/student/announcement/index.ts
+++ b/src/apis/dtos/student/announcement/index.ts
@@ -4,18 +4,7 @@ export class MyAnnouncement {
   writer: string;
   createdAt: Date;
 
-  constructor({
-    id,
-    title,
-    writer,
-    createdAt,
-  }: {
-    id: number;
-    title: string;
-    content: string;
-    writer: string;
-    createdAt: Date;
-  }) {
+  constructor({ id, title, writer, createdAt }: { id: number; title: string; writer: string; createdAt: Date }) {
     this.id = id;
     this.title = title;
     this.writer = writer;
@@ -32,5 +21,37 @@ export class MyAnnouncementList {
     this.content = content;
     this.totalElements = totalElements;
     this.isLast = last;
+  }
+}
+
+export class MyAnnouncementDetail {
+  id: number;
+  title: string;
+  content: string;
+  writer: string;
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor({
+    id,
+    title,
+    writer,
+    createdAt,
+    content,
+    updatedAt,
+  }: {
+    id: number;
+    title: string;
+    content: string;
+    writer: string;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    this.id = id;
+    this.title = title;
+    this.content = content;
+    this.writer = writer;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
 }

--- a/src/apis/student/announcement/index.ts
+++ b/src/apis/student/announcement/index.ts
@@ -1,8 +1,14 @@
-import { MyAnnouncementList } from "@/apis/dtos/student/announcement";
+import { MyAnnouncementDetail, MyAnnouncementList } from "@/apis/dtos/student/announcement";
 import { https } from "@/apis/instance/https";
 
 export const getMyAnnouncementList = async (page: number, size: number, direction: "asc" | "desc") => {
   const { data } = await https.get(`announces/me?page=${page}&size=${size}&direction=${direction}&sort=createdAt`);
 
   return new MyAnnouncementList(data);
+};
+
+export const getMyAnnouncementDetail = async (announcementId: string) => {
+  const { data } = await https.get(`announces/me/${announcementId}`);
+
+  return new MyAnnouncementDetail(data);
 };

--- a/src/app/student/my-announcement/[announcementId]/page.tsx
+++ b/src/app/student/my-announcement/[announcementId]/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import MyAnnouncementDetail from "@/components/page/student/my-announcement";
+import { Suspense } from "react";
+
+export default function MyAnnouncementDetailPage() {
+  return (
+    <>
+      <Suspense>
+        <MyAnnouncementDetail />
+      </Suspense>
+    </>
+  );
+}

--- a/src/app/student/my-announcement/[announcementId]/page.tsx
+++ b/src/app/student/my-announcement/[announcementId]/page.tsx
@@ -5,10 +5,8 @@ import { Suspense } from "react";
 
 export default function MyAnnouncementDetailPage() {
   return (
-    <>
-      <Suspense>
-        <MyAnnouncementDetail />
-      </Suspense>
-    </>
+    <Suspense>
+      <MyAnnouncementDetail />
+    </Suspense>
   );
 }

--- a/src/components/page/student/my-announcement/MyAnnouncementDetailInfoForm/index.module.scss
+++ b/src/components/page/student/my-announcement/MyAnnouncementDetailInfoForm/index.module.scss
@@ -15,7 +15,7 @@
 
 .textarea {
   min-height: 20rem;
-  height: auth;
+  height: auto;
 }
 
 .date {

--- a/src/components/page/student/my-announcement/MyAnnouncementDetailInfoForm/index.module.scss
+++ b/src/components/page/student/my-announcement/MyAnnouncementDetailInfoForm/index.module.scss
@@ -1,0 +1,23 @@
+.header {
+  background-color: #f9f9f9;
+  padding: 2rem;
+  border-radius: 1rem 1rem 0 0;
+  border: 0.1rem solid #c1c1c1;
+}
+
+.contentContainer {
+  padding: 2rem;
+  border: 0.1rem solid #c1c1c1;
+  border-top: 0rem;
+  @include flexSort(column, null, null, 2rem);
+  border-radius: 0 0 1rem 1rem;
+}
+
+.textarea {
+  min-height: 20rem;
+  height: auth;
+}
+
+.date {
+  margin-left: auto;
+}

--- a/src/components/page/student/my-announcement/MyAnnouncementDetailInfoForm/index.tsx
+++ b/src/components/page/student/my-announcement/MyAnnouncementDetailInfoForm/index.tsx
@@ -22,7 +22,7 @@ export default function MyAnnouncementDetailInfoForm({ formData }: AnnouncementD
         <Txt weight="medium">공지사항</Txt>
       </header>
       <div className={cn("contentContainer")}>
-        <TextInput id="title" label="작성자" type="text" value={formData.writer} readOnly />
+        <TextInput id="writer" label="작성자" type="text" value={formData.writer} readOnly />
         <TextInput id="title" label="제목" type="text" value={formData.title} readOnly />
         <LabeledTextarea
           id="content"

--- a/src/components/page/student/my-announcement/MyAnnouncementDetailInfoForm/index.tsx
+++ b/src/components/page/student/my-announcement/MyAnnouncementDetailInfoForm/index.tsx
@@ -1,0 +1,40 @@
+import Txt from "@/components/design-system/Txt";
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import TextInput from "@/components/common/TextInput";
+import { LabeledTextarea } from "@/components/common/LabeledTextarea";
+import { MyAnnouncementDetailForm } from "@/types/student/announcement";
+import { formatToKoreanTime } from "@/utils/date";
+import { getEffectiveDate } from "@/functions/getEffectiveDate";
+
+const cn = classNames.bind(styles);
+
+interface AnnouncementDetailFormProps {
+  formData: MyAnnouncementDetailForm;
+}
+
+export default function MyAnnouncementDetailInfoForm({ formData }: AnnouncementDetailFormProps) {
+  const { date, isUpdate } = getEffectiveDate(formData.createdAt as Date, formData.updatedAt as Date);
+
+  return (
+    <div>
+      <header className={cn("header")}>
+        <Txt weight="medium">공지사항</Txt>
+      </header>
+      <div className={cn("contentContainer")}>
+        <TextInput id="title" label="작성자" type="text" value={formData.writer} readOnly />
+        <TextInput id="title" label="제목" type="text" value={formData.title} readOnly />
+        <LabeledTextarea
+          id="content"
+          label="내용"
+          value={formData.content}
+          textareaClassName={cn("textarea")}
+          readOnly
+        />
+        <Txt size="small" className={cn("date")}>
+          {`작성일 : ${formatToKoreanTime(date)} ${isUpdate ? "(수정됨)" : ""}`}
+        </Txt>
+      </div>
+    </div>
+  );
+}

--- a/src/components/page/student/my-announcement/index.module.scss
+++ b/src/components/page/student/my-announcement/index.module.scss
@@ -1,0 +1,9 @@
+.container {
+  padding: 4rem;
+  @include flexSort(column, null, null, 3rem);
+}
+
+.skeleton {
+  margin: 4rem;
+  height: 45rem;
+}

--- a/src/components/page/student/my-announcement/index.tsx
+++ b/src/components/page/student/my-announcement/index.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import Txt from "@/components/design-system/Txt";
+import MyAnnouncementDetailInfoForm from "@/components/page/student/my-announcement/MyAnnouncementDetailInfoForm";
+import { useMyAnnouncementDetailForm } from "@/hooks/student/announcement/useMyAnnouncementDetailForm";
+import Skeleton from "@/components/common/Skeleton";
+
+const cn = classNames.bind(styles);
+
+export default function MyAnnouncementDetail() {
+  const { formData, isPending, isError } = useMyAnnouncementDetailForm();
+
+  if (isPending) {
+    return <Skeleton className={cn("skeleton")} />;
+  }
+
+  if (isError) {
+    return null;
+  }
+
+  return (
+    <div className={cn("container")}>
+      <Txt color="primary" size="h3" weight="medium">
+        공지사항
+      </Txt>
+      <MyAnnouncementDetailInfoForm formData={formData} />
+    </div>
+  );
+}

--- a/src/functions/getEffectiveDate.ts
+++ b/src/functions/getEffectiveDate.ts
@@ -1,0 +1,9 @@
+import { formatToKoreanFullTime } from "@/utils/date";
+
+export const getEffectiveDate = (createdAt: Date, updatedAt: Date) => {
+  if (formatToKoreanFullTime(createdAt) === formatToKoreanFullTime(updatedAt)) {
+    return { date: createdAt, isUpdate: false };
+  }
+
+  return { date: updatedAt, isUpdate: true };
+};

--- a/src/hooks/student/announcement/useMyAnnouncementDetailForm.ts
+++ b/src/hooks/student/announcement/useMyAnnouncementDetailForm.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { useGetAnnouncementId } from "@/hooks/common/useGetPageAnnouncementId";
+import { MyAnnouncementDetailForm } from "@/types/student/announcement";
+import { useGetMyAnnouncementDetail } from "@/hooks/tanstack-query/student/announcement/useGetMyAnnouncementDetail";
+
+export const useMyAnnouncementDetailForm = () => {
+  const { announcementId } = useGetAnnouncementId();
+
+  const { data, isPending, isError } = useGetMyAnnouncementDetail(announcementId);
+
+  const [formData, setFormData] = useState<MyAnnouncementDetailForm>({
+    title: "",
+    content: "",
+    createdAt: null,
+    updatedAt: null,
+    writer: "",
+  });
+
+  useEffect(() => {
+    if (data) {
+      setFormData({
+        title: data.title,
+        content: data.content,
+        createdAt: data.createdAt,
+        updatedAt: data.updatedAt,
+        writer: data.writer,
+      });
+    }
+  }, [data]);
+
+  return {
+    formData,
+    isPending,
+    isError,
+  };
+};

--- a/src/hooks/tanstack-query/student/announcement/useGetMyAnnouncementDetail.ts
+++ b/src/hooks/tanstack-query/student/announcement/useGetMyAnnouncementDetail.ts
@@ -1,0 +1,10 @@
+import { getMyAnnouncementDetail } from "@/apis/student/announcement";
+import { useQuery } from "@tanstack/react-query";
+
+export const useGetMyAnnouncementDetail = (announcementId: string) => {
+  return useQuery({
+    queryKey: ["myAnnouncementDetail", announcementId],
+    queryFn: () => getMyAnnouncementDetail(announcementId),
+    enabled: !!announcementId,
+  });
+};

--- a/src/types/student/announcement/index.ts
+++ b/src/types/student/announcement/index.ts
@@ -1,0 +1,7 @@
+export interface MyAnnouncementDetailForm {
+  title: string;
+  content: string;
+  writer: string;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -9,3 +9,16 @@ export const formatToKoreanTime = (isoDate: Date): string => {
 
   return `${year}-${month}-${day} ${hours}시 ${minutes}분`;
 };
+
+export const formatToKoreanFullTime = (isoDate: Date): string => {
+  const date = new Date(isoDate);
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = date.getHours();
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
+
+  return `${year}-${month}-${day} ${hours}시 ${minutes}분 ${seconds}초`;
+};


### PR DESCRIPTION
### 개요

close #87 

### 작업사항

- 나의 학과에 해당하는 공지사항 상세 페이지 구현
- 나의 학과에 해당하는 공지사항 상세 정보를 가져오는 api 함수 구현
- 나의 학과에 해당하는 공지사항 상세 정보를 가져오는 api 관련 tanstack query 훅 구현
- 나의 학과에 해당하는 공지사항 상세 페이지에서 사용하는 useMyAnnouncementDetailForm 커스텀 훅 구현

### 변경로직

- 내용을 적어주세요.

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 학생 공지사항 상세 페이지가 추가되어, 개별 공지사항의 제목, 작성자, 내용, 생성일, 수정일 정보를 확인할 수 있습니다.
    - 공지사항 상세 정보를 불러오는 기능과 상태 관리 훅이 도입되어 사용자 경험이 향상되었습니다.
- **스타일**
    - 공지사항 상세 정보 폼 및 페이지에 대한 새로운 스타일이 적용되었습니다.
- **기타**
    - 날짜 및 시간 포맷이 초 단위까지 한글로 표시되는 기능이 추가되었습니다.
    - 공지사항 생성일과 수정일 중 실제 적용 날짜를 판단하는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->