### PR TITLE
feat: 나의 학과에 해당하는 이벤트 목록 페이지 구현

### DIFF
--- a/src/apis/dtos/student/event/index.ts
+++ b/src/apis/dtos/student/event/index.ts
@@ -29,3 +29,15 @@ export class MyEvent {
     this.availableLockerCount = availableLockerCount;
   }
 }
+
+export class MyEventList {
+  content: MyEvent[];
+  totalElements: number;
+  isLast: boolean;
+
+  constructor({ content, totalElements, last }: { content: MyEvent[]; totalElements: number; last: boolean }) {
+    this.content = content;
+    this.totalElements = totalElements;
+    this.isLast = last;
+  }
+}

--- a/src/apis/student/event/index.ts
+++ b/src/apis/student/event/index.ts
@@ -1,0 +1,8 @@
+import { MyEventList } from "@/apis/dtos/student/event";
+import { https } from "@/apis/instance/https";
+
+export const getMyEventList = async (page: number, size: number, direction: "asc" | "desc") => {
+  const { data } = await https.get(`events/me?page=${page}&size=${size}&direction=${direction}&sort=createdAt`);
+
+  return new MyEventList(data);
+};

--- a/src/app/student/my-event-list/page.tsx
+++ b/src/app/student/my-event-list/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import MyEventList from "@/components/page/student/my-event-list";
+import { Suspense } from "react";
+
+export default function MyEventListPage() {
+  return (
+    <>
+      <Suspense>
+        <MyEventList />
+      </Suspense>
+    </>
+  );
+}

--- a/src/components/page/student/DepartmentInfo/DepartmentInfoApplyLocker/index.module.scss
+++ b/src/components/page/student/DepartmentInfo/DepartmentInfoApplyLocker/index.module.scss
@@ -5,3 +5,12 @@
 .container {
   @include flexSort(column, null, null, 1.5rem);
 }
+
+.moreLinkContainer {
+  @include flexSort(row, flex-end, null, null);
+}
+
+.moreLink {
+  text-decoration-line: underline;
+  text-underline-position: from-font;
+}

--- a/src/components/page/student/DepartmentInfo/DepartmentInfoApplyLocker/index.tsx
+++ b/src/components/page/student/DepartmentInfo/DepartmentInfoApplyLocker/index.tsx
@@ -29,7 +29,7 @@ export default function DepartmentInfoApplyLocker() {
       <Txt color="secondary" weight="bold" size="h3">
         사물함 신청
       </Txt>
-      <MyLockerEventCarousel myEventList={data.content} options={OPTIONS} />{" "}
+      <MyLockerEventCarousel myEventList={data.content} options={OPTIONS} />
       <div className={cn("moreLinkContainer")}>
         <Link href={ROUTE.STUDENT.MY_EVENT_LIST}>
           <Txt size="tiny" className={cn("moreLink")}>

--- a/src/components/page/student/DepartmentInfo/DepartmentInfoApplyLocker/index.tsx
+++ b/src/components/page/student/DepartmentInfo/DepartmentInfoApplyLocker/index.tsx
@@ -7,6 +7,8 @@ import MyLockerEventCarousel from "../MyLockerEventCarousel";
 import { EmblaOptionsType } from "embla-carousel";
 import { useGetMyEvent } from "@/hooks/tanstack-query/student/department-info/useGetMyEvent";
 import Skeleton from "@/components/common/Skeleton";
+import Link from "next/link";
+import { ROUTE } from "@/constants/routes";
 
 const cn = classNames.bind(styles);
 
@@ -27,7 +29,14 @@ export default function DepartmentInfoApplyLocker() {
       <Txt color="secondary" weight="bold" size="h3">
         사물함 신청
       </Txt>
-      <MyLockerEventCarousel myEventList={data.content} options={OPTIONS} />
+      <MyLockerEventCarousel myEventList={data.content} options={OPTIONS} />{" "}
+      <div className={cn("moreLinkContainer")}>
+        <Link href={ROUTE.STUDENT.MY_EVENT_LIST}>
+          <Txt size="tiny" className={cn("moreLink")}>
+            더보기
+          </Txt>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/components/page/student/my-event-list/index.module.scss
+++ b/src/components/page/student/my-event-list/index.module.scss
@@ -1,0 +1,61 @@
+.skeleton {
+  width: 100%;
+  height: 30rem;
+}
+
+.container {
+  padding: 4rem;
+  @include flexSort(column, null, null, 3rem);
+}
+
+.tableHeaderContainer {
+  background-color: $primary;
+  border-left: 0.2rem solid $primary;
+  border-right: 0.2rem solid $primary;
+}
+
+.tableHeader {
+  padding: 2rem;
+
+  @include mobile {
+    padding: 1rem;
+  }
+}
+
+.tableHeaderTitle {
+  @include mobile {
+    font-size: 1.7rem !important;
+  }
+}
+
+.tr {
+  border-bottom: 0.2rem solid $primary;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f0f0f0;
+  }
+}
+
+.tableBodyTitle {
+  @include mobile {
+    font-size: 1.5rem !important;
+  }
+}
+
+.tableData {
+  text-align: center;
+  padding: 2rem;
+
+  &:first-child {
+    border-left: 0.2rem solid $primary;
+  }
+
+  &:last-child {
+    border-right: 0.2rem solid $primary;
+  }
+
+  @include mobile {
+    padding: 1rem;
+  }
+}

--- a/src/components/page/student/my-event-list/index.tsx
+++ b/src/components/page/student/my-event-list/index.tsx
@@ -11,16 +11,8 @@ import { useMyEventList } from "@/hooks/student/event/useMyEventList";
 const cn = classNames.bind(styles);
 
 export default function MyEventList() {
-  const {
-    myAnnouncementList,
-    totalElements,
-    currentPage,
-    setPage,
-    itemsPerPage,
-    pagesPerGroup,
-    onEventClick,
-    isLoading,
-  } = useMyEventList();
+  const { myEventList, totalElements, currentPage, setPage, itemsPerPage, pagesPerGroup, onEventClick, isLoading } =
+    useMyEventList();
 
   return (
     <div className={cn("container")}>
@@ -57,23 +49,23 @@ export default function MyEventList() {
           </tbody>
         ) : (
           <tbody>
-            {myAnnouncementList.map((myAnnouncement) => (
-              <tr className={cn("tr")} key={myAnnouncement.id} onClick={() => onEventClick(myAnnouncement.id)}>
+            {myEventList.map((myEvent) => (
+              <tr className={cn("tr")} key={myEvent.id} onClick={() => onEventClick(myEvent.id)}>
                 <td className={cn("tableData")}>
                   <Txt size="h6" className={cn("tableBodyTitle")}>
-                    {myAnnouncement.title}
+                    {myEvent.title}
                   </Txt>
                 </td>
                 <td className={cn("tableData")}>
                   <Txt size="h6" className={cn("tableBodyTitle")}>
-                    {myAnnouncement.departmentNickname}
+                    {myEvent.departmentNickname}
                   </Txt>
                 </td>
                 <td className={cn("tableData")}>
                   <Txt
                     size="h6"
                     className={cn("tableBodyTitle")}
-                  >{`${formatToKoreanTime(myAnnouncement.startAt)} ~ ${formatToKoreanTime(myAnnouncement.endAt)}`}</Txt>
+                  >{`${formatToKoreanTime(myEvent.startAt)} ~ ${formatToKoreanTime(myEvent.endAt)}`}</Txt>
                 </td>
               </tr>
             ))}

--- a/src/components/page/student/my-event-list/index.tsx
+++ b/src/components/page/student/my-event-list/index.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import Txt from "@/components/design-system/Txt";
+import Pagination from "@/components/common/Pagination";
+import { formatToKoreanTime } from "@/utils/date";
+import Skeleton from "@/components/common/Skeleton";
+import { useMyEventList } from "@/hooks/student/event/useMyEventList";
+
+const cn = classNames.bind(styles);
+
+export default function MyEventList() {
+  const {
+    myAnnouncementList,
+    totalElements,
+    currentPage,
+    setPage,
+    itemsPerPage,
+    pagesPerGroup,
+    onEventClick,
+    isLoading,
+  } = useMyEventList();
+
+  return (
+    <div className={cn("container")}>
+      <Txt color="primary" size="h3" weight="medium">
+        이벤트 목록
+      </Txt>
+      <table>
+        <thead className={cn("tableHeaderContainer")}>
+          <tr>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium" className={cn("tableHeaderTitle")}>
+                제목
+              </Txt>
+            </th>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium" className={cn("tableHeaderTitle")}>
+                작성자
+              </Txt>
+            </th>
+            <th className={cn("tableHeader")}>
+              <Txt color="white" weight="medium" className={cn("tableHeaderTitle")}>
+                이벤트 시간
+              </Txt>
+            </th>
+          </tr>
+        </thead>
+        {isLoading ? (
+          <tbody>
+            <tr>
+              <td colSpan={3}>
+                <Skeleton className={cn("skeleton")} />
+              </td>
+            </tr>
+          </tbody>
+        ) : (
+          <tbody>
+            {myAnnouncementList.map((myAnnouncement) => (
+              <tr className={cn("tr")} key={myAnnouncement.id} onClick={() => onEventClick(myAnnouncement.id)}>
+                <td className={cn("tableData")}>
+                  <Txt size="h6" className={cn("tableBodyTitle")}>
+                    {myAnnouncement.title}
+                  </Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt size="h6" className={cn("tableBodyTitle")}>
+                    {myAnnouncement.departmentNickname}
+                  </Txt>
+                </td>
+                <td className={cn("tableData")}>
+                  <Txt
+                    size="h6"
+                    className={cn("tableBodyTitle")}
+                  >{`${formatToKoreanTime(myAnnouncement.startAt)} ~ ${formatToKoreanTime(myAnnouncement.endAt)}`}</Txt>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        )}
+      </table>
+      <Pagination
+        pagesPerGroup={pagesPerGroup}
+        currentPage={currentPage}
+        itemsPerPage={itemsPerPage}
+        totalItems={totalElements}
+        setPage={setPage}
+      />
+    </div>
+  );
+}

--- a/src/constants/routes/index.ts
+++ b/src/constants/routes/index.ts
@@ -8,6 +8,7 @@ export const ROUTE = {
     MY_ANNOUNCEMENT_LIST: "/student/my-announcement-list",
     APPLY_LOCKER: "/student/apply-locker",
     MY_EVENT_LIST: "/student/my-event-list",
+    MY_EVENT: "/student/my-event",
   },
   COMMITTEE: {
     MAIN: "/committee/",

--- a/src/constants/routes/index.ts
+++ b/src/constants/routes/index.ts
@@ -7,6 +7,7 @@ export const ROUTE = {
     MY_ANNOUNCEMENT: "/student/my-announcement",
     MY_ANNOUNCEMENT_LIST: "/student/my-announcement-list",
     APPLY_LOCKER: "/student/apply-locker",
+    MY_EVENT_LIST: "/student/my-event-list",
   },
   COMMITTEE: {
     MAIN: "/committee/",

--- a/src/hooks/student/event/useMyEventList.ts
+++ b/src/hooks/student/event/useMyEventList.ts
@@ -11,7 +11,7 @@ export const useMyEventList = () => {
 
   const { data, isLoading } = useGetMyEventListQuery(queryParams);
 
-  const myAnnouncementList = data?.content || [];
+  const myEventList = data?.content || [];
   const totalElements = data?.totalElements || 0;
 
   const onEventClick = (id: string) => {
@@ -19,7 +19,7 @@ export const useMyEventList = () => {
   };
 
   return {
-    myAnnouncementList,
+    myEventList,
     totalElements,
     currentPage,
     setPage,

--- a/src/hooks/student/event/useMyEventList.ts
+++ b/src/hooks/student/event/useMyEventList.ts
@@ -1,0 +1,31 @@
+import { useGetPageParams } from "@/hooks/common/useGetPageParams";
+import { useRouter } from "next/navigation";
+import { ROUTE } from "@/constants/routes";
+import { useMyEventPagination } from "../event/useMyEventPagination";
+import { useGetMyEventListQuery } from "@/hooks/tanstack-query/student/event/useGetMyEventListQuery";
+
+export const useMyEventList = () => {
+  const router = useRouter();
+  const { page: currentPage } = useGetPageParams();
+  const { pagesPerGroup, queryParams, setPage } = useMyEventPagination(currentPage);
+
+  const { data, isLoading } = useGetMyEventListQuery(queryParams);
+
+  const myAnnouncementList = data?.content || [];
+  const totalElements = data?.totalElements || 0;
+
+  const onEventClick = (id: string) => {
+    router.push(`${ROUTE.STUDENT.MY_EVENT}/${id}`);
+  };
+
+  return {
+    myAnnouncementList,
+    totalElements,
+    currentPage,
+    setPage,
+    itemsPerPage: queryParams.size,
+    pagesPerGroup,
+    onEventClick,
+    isLoading,
+  };
+};

--- a/src/hooks/student/event/useMyEventPagination.ts
+++ b/src/hooks/student/event/useMyEventPagination.ts
@@ -1,0 +1,27 @@
+import { useRouter, useSearchParams } from "next/navigation";
+
+export const useMyEventPagination = (page: number) => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const pagesPerGroup = 5;
+
+  const setPage = (page: number) => {
+    const newParams = new URLSearchParams(searchParams.toString());
+    newParams.set("page", page.toString());
+
+    router.replace(`?${newParams.toString()}`);
+  };
+
+  const queryParams: { page: number; size: number; direction: "asc" | "desc" } = {
+    page: page - 1,
+    size: 4,
+    direction: "desc",
+  };
+
+  return {
+    setPage,
+    pagesPerGroup,
+    queryParams,
+  };
+};

--- a/src/hooks/tanstack-query/student/event/useGetMyEventListQuery.ts
+++ b/src/hooks/tanstack-query/student/event/useGetMyEventListQuery.ts
@@ -1,0 +1,16 @@
+import { getMyEventList } from "@/apis/student/event";
+import { useQuery } from "@tanstack/react-query";
+
+interface MyEventListQueryParams {
+  page: number;
+  size: number;
+  direction: "asc" | "desc";
+}
+
+export const useGetMyEventListQuery = ({ page, size, direction }: MyEventListQueryParams) => {
+  return useQuery({
+    queryKey: ["myEventList", page, size, direction],
+    queryFn: () => getMyEventList(page, size, direction),
+    enabled: page >= 0,
+  });
+};


### PR DESCRIPTION
### 개요

close #89 

### 작업사항

- 나의 학과에 해당하는 이벤트 목록 페이지 구현
- 나의 학과에 해당하는 이벤트 목록 불러오는 api 함수 구현
- 나의 학과에 해당하는 이벤트 목록 불러오는 api 관련 tanstack query 훅 구현
- 나의 학과에 해당하는 이벤트 목록 페이지에서 사용하는 useMyEventList 커스텀 훅 구현

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 학생용 이벤트 목록 페이지가 추가되었습니다. 이제 학생은 자신의 이벤트 목록을 확인할 수 있습니다.
    - 이벤트 목록은 페이지네이션이 적용되어 있으며, 각 이벤트를 클릭하여 상세 페이지로 이동할 수 있습니다.
    - "더보기" 링크가 학과 사물함 안내 섹션에 추가되어, 이벤트 목록 페이지로 쉽게 이동할 수 있습니다.
    - 학생 이벤트 목록 API와 관련 커스텀 훅들이 도입되어 데이터 조회 및 페이지네이션이 원활하게 처리됩니다.

- **스타일**
    - 이벤트 목록 페이지 및 "더보기" 링크에 대한 새로운 스타일이 적용되었습니다.
    - 테이블, 스켈레톤 로더, 반응형 폰트 및 버튼 스타일이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->