### PR TITLE
feat: 위원회 페이지에서 로그인 권한이 없을 시 로그인 페이지로 이동

### DIFF
--- a/src/hooks/committee/announcement/useAnnouncementForm.ts
+++ b/src/hooks/committee/announcement/useAnnouncementForm.ts
@@ -6,11 +6,15 @@ import { CREATE_ANNOUNCEMENT_VALIDATION } from "@/constants/validation/createAnn
 import { useGetAnnouncement } from "@/hooks/tanstack-query/committee/announcement/useGetAnnouncement";
 import { useGetAnnouncementId } from "@/hooks/common/useGetPageAnnouncementId";
 import { usePutAnnouncement } from "@/hooks/tanstack-query/committee/announcement/usePutAnnouncement";
+import { useCommitteeCertification } from "@/hooks/committee/sign-in/useCommitteeCertification";
+import { ApiResponseError } from "@/types/common/api";
 
 export const useAnnouncementForm = () => {
   const { announcementId } = useGetAnnouncementId();
 
-  const { data } = useGetAnnouncement(announcementId);
+  const { data, isError, error } = useGetAnnouncement(announcementId);
+
+  useCommitteeCertification(isError, error as ApiResponseError);
 
   const [isPutMode, setIsPutMode] = useState(false);
 
@@ -30,7 +34,7 @@ export const useAnnouncementForm = () => {
 
   const { onPutAnnouncement: putAnnouncement } = usePutAnnouncement(announcementId);
 
-  let organizations = useOrganizationsQuery("학생회");
+  let { data: organizations } = useOrganizationsQuery("학생회");
 
   if (!organizations) {
     organizations = [{ id: 0, value: "값을 선택해주세요." }];

--- a/src/hooks/committee/announcement/useAnnouncementList.ts
+++ b/src/hooks/committee/announcement/useAnnouncementList.ts
@@ -3,13 +3,16 @@ import { useRouter } from "next/navigation";
 import { ROUTE } from "@/constants/routes";
 import { useAnnouncementPagination } from "@/hooks/committee/announcement/useAnnouncementPagination";
 import { useGetAnnouncementListQuery } from "@/hooks/tanstack-query/committee/announcement/useGetAnnouncementListQuery";
+import { useCommitteeCertification } from "@/hooks/committee/sign-in/useCommitteeCertification";
+import { ApiResponseError } from "@/types/common/api";
 
 export const useAnnouncementList = () => {
   const router = useRouter();
   const { page: currentPage } = useGetPageParams();
   const { pagesPerGroup, queryParams, setPage } = useAnnouncementPagination(currentPage);
 
-  const { data, isLoading } = useGetAnnouncementListQuery(queryParams);
+  const { data, isLoading, isError, error } = useGetAnnouncementListQuery(queryParams);
+  useCommitteeCertification(isError, error as ApiResponseError);
 
   const announcementList = data?.content || [];
   const totalElements = data?.totalElements || 0;

--- a/src/hooks/committee/announcement/useCreateAnnouncementForm.ts
+++ b/src/hooks/committee/announcement/useCreateAnnouncementForm.ts
@@ -18,7 +18,7 @@ export const useCreateAnnouncementForm = () => {
   });
   const { onCreateAnnouncement: createAnnouncement } = useCreateAnnouncement();
 
-  let organizations = useOrganizationsQuery("학생회");
+  let { data: organizations } = useOrganizationsQuery("학생회");
 
   if (!organizations) {
     organizations = [{ id: 0, value: "값을 선택해주세요." }];

--- a/src/hooks/committee/apply/useApplyDetail.ts
+++ b/src/hooks/committee/apply/useApplyDetail.ts
@@ -2,13 +2,17 @@ import { useGetPageParams } from "@/hooks/common/useGetPageParams";
 import { useApplyDetailPagination } from "@/hooks/committee/apply/useApplyDetailPagination";
 import { useGetApplyDetailQuery } from "@/hooks/tanstack-query/committee/event/useGetApplyDetail";
 import { useGetApplyDetailPageEventId } from "../apply/useGetApplyDetailPageEventId";
+import { ApiResponseError } from "@/types/common/api";
+import { useCommitteeCertification } from "@/hooks/committee/sign-in/useCommitteeCertification";
 
 export const useApplyDetail = () => {
   const { page: currentPage } = useGetPageParams();
   const { eventId } = useGetApplyDetailPageEventId();
 
   const { pagesPerGroup, queryParams, setPage } = useApplyDetailPagination(currentPage, eventId);
-  const { data, isLoading } = useGetApplyDetailQuery(queryParams);
+  const { data, isLoading, isError, error } = useGetApplyDetailQuery(queryParams);
+
+  useCommitteeCertification(isError, error as ApiResponseError);
 
   const ApplyDetailList = data?.content || [];
   const totalElements = data?.totalElements || 0;

--- a/src/hooks/committee/apply/useApplyList.ts
+++ b/src/hooks/committee/apply/useApplyList.ts
@@ -3,13 +3,17 @@ import { useEventPagination } from "@/hooks/committee/event/useEventPagination";
 import { useGetApplyListQuery } from "@/hooks/tanstack-query/committee/event/useGetApplyList";
 import { useRouter } from "next/navigation";
 import { ROUTE } from "@/constants/routes";
+import { useCommitteeCertification } from "@/hooks/committee/sign-in/useCommitteeCertification";
+import { ApiResponseError } from "@/types/common/api";
 
 export const useApplyList = () => {
   const router = useRouter();
   const { page: currentPage } = useGetPageParams();
   const { pagesPerGroup, queryParams, setPage } = useEventPagination(currentPage);
 
-  const { data, isLoading } = useGetApplyListQuery(queryParams);
+  const { data, isLoading, isError, error } = useGetApplyListQuery(queryParams);
+
+  useCommitteeCertification(isError, error as ApiResponseError);
 
   const applyList = data?.content || [];
   const totalElements = data?.totalElements || 0;

--- a/src/hooks/committee/approve-wait/useApproveWaitList.ts
+++ b/src/hooks/committee/approve-wait/useApproveWaitList.ts
@@ -2,12 +2,15 @@ import { useGetPageParams } from "@/hooks/common/useGetPageParams";
 import { useApproveWaitPagination } from "./useApproveWaitPagination";
 import { useGetApproveWaitListQuery } from "@/hooks/tanstack-query/committee/approve-wait/useGetApproveWaitListQuery";
 import { usePostApprove } from "@/hooks/tanstack-query/committee/approve-wait/usePostApprove";
+import { ApiResponseError } from "@/types/common/api";
+import { useCommitteeCertification } from "@/hooks/committee/sign-in/useCommitteeCertification";
 
 export const useApproveWaitList = () => {
   const { page: currentPage } = useGetPageParams();
   const { pagesPerGroup, queryParams, setPage } = useApproveWaitPagination(currentPage);
 
-  const { data, isLoading } = useGetApproveWaitListQuery(queryParams);
+  const { data, isLoading, isError, error } = useGetApproveWaitListQuery(queryParams);
+  useCommitteeCertification(isError, error as ApiResponseError);
 
   const { onApprove } = usePostApprove();
 

--- a/src/hooks/committee/event/useCreateEventForm.ts
+++ b/src/hooks/committee/event/useCreateEventForm.ts
@@ -38,7 +38,7 @@ export const useCreateEventForm = () => {
   });
   const { onCreateEvent: createEvent } = useCreateEvent();
 
-  let organizations = useOrganizationsQuery("학생회");
+  let { data: organizations } = useOrganizationsQuery("학생회");
 
   if (!organizations) {
     organizations = [{ id: 0, value: "값을 선택해주세요." }];

--- a/src/hooks/committee/event/useEventList.ts
+++ b/src/hooks/committee/event/useEventList.ts
@@ -3,12 +3,15 @@ import { useGetPageParams } from "@/hooks/common/useGetPageParams";
 import { useEventPagination } from "@/hooks/committee/event/useEventPagination";
 import { useDeleteEvent } from "@/hooks/tanstack-query/committee/event/useDeleteEvent";
 import { usePutEventPublish } from "@/hooks/tanstack-query/committee/event/usePutEventPublish";
+import { useCommitteeCertification } from "../sign-in/useCommitteeCertification";
+import { ApiResponseError } from "@/types/common/api";
 
 export const useEventList = () => {
   const { page: currentPage } = useGetPageParams();
   const { pagesPerGroup, queryParams, setPage } = useEventPagination(currentPage);
 
-  const { data, isLoading } = useGetEventListQuery(queryParams);
+  const { data, isLoading, isError, error } = useGetEventListQuery(queryParams);
+  useCommitteeCertification(isError, error as ApiResponseError);
 
   const { onDeleteEvent } = useDeleteEvent(queryParams);
 

--- a/src/hooks/committee/sign-in/useCommitteeCertification.ts
+++ b/src/hooks/committee/sign-in/useCommitteeCertification.ts
@@ -1,0 +1,20 @@
+import { ROUTE } from "@/constants/routes";
+import { ApiResponseError } from "@/types/common/api";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export const useCommitteeCertification = (isError: boolean, error: ApiResponseError) => {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isError && error.response.status === 401) {
+      router.push(ROUTE.COMMITTEE.MAIN);
+      alert("로그인 후 이용해주세요.");
+    }
+
+    if (isError && error.response.status === 403) {
+      router.push(ROUTE.COMMITTEE.MAIN);
+      alert("권한이 없습니다.");
+    }
+  }, [isError, error, router]);
+};

--- a/src/hooks/committee/sign-up/useCommitteeSignUpForm.ts
+++ b/src/hooks/committee/sign-up/useCommitteeSignUpForm.ts
@@ -13,7 +13,7 @@ const useCommitteeSignUpForm = () => {
 
   const { error, setFormError, clearError } = useFormError();
 
-  let organizations = useOrganizationsQuery(formData.category.value);
+  let { data: organizations } = useOrganizationsQuery(formData.category.value);
   let departments = useDepartmentsQuery(formData.affiliation.id);
 
   if (!organizations) {

--- a/src/hooks/common/useCommitteeHeader.ts
+++ b/src/hooks/common/useCommitteeHeader.ts
@@ -1,19 +1,9 @@
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { useGetMyInfo } from "@/hooks/tanstack-query/common/my-info/useGetMyInfo";
-import { useEffect } from "react";
-import { ROUTE } from "@/constants/routes";
 
 export const useCommitteeHeader = () => {
-  const { data, isPending, isError, error } = useGetMyInfo();
-  const router = useRouter();
+  const { data, isPending, isError } = useGetMyInfo();
   const path = usePathname();
-
-  useEffect(() => {
-    if (isError && error.response.status === 401) {
-      alert("로그인 후 이용해주세요.");
-      router.push(ROUTE.COMMITTEE.MAIN);
-    }
-  }, [isError, error, router]);
 
   return { data, isPending, isError, path };
 };

--- a/src/hooks/student/sign-up/useStudentSignUp.ts
+++ b/src/hooks/student/sign-up/useStudentSignUp.ts
@@ -28,7 +28,7 @@ const useStudentSignUpForm = () => {
 
   const { onVerifyCertificationCode } = useVerifyCertificationCode(setCountdown);
 
-  let organizations = useOrganizationsQuery("학생회");
+  let { data: organizations } = useOrganizationsQuery("학생회");
 
   if (!organizations) {
     organizations = [{ id: 0, value: "값을 선택해주세요." }];

--- a/src/hooks/tanstack-query/committee/announcement/useGetAnnouncement.ts
+++ b/src/hooks/tanstack-query/committee/announcement/useGetAnnouncement.ts
@@ -1,8 +1,10 @@
 import { getAnnouncement } from "@/apis/committee/announcement";
+import { AnnouncementDetail } from "@/apis/dtos/committee/announcement";
+import { ApiResponseError } from "@/types/common/api";
 import { useQuery } from "@tanstack/react-query";
 
 export const useGetAnnouncement = (announcementId: string) => {
-  return useQuery({
+  return useQuery<AnnouncementDetail, ApiResponseError>({
     queryKey: ["announcement", announcementId],
     queryFn: () => getAnnouncement(announcementId),
     enabled: !!announcementId,

--- a/src/hooks/tanstack-query/committee/announcement/useGetAnnouncementListQuery.ts
+++ b/src/hooks/tanstack-query/committee/announcement/useGetAnnouncementListQuery.ts
@@ -1,4 +1,6 @@
 import { getAnnouncementList } from "@/apis/committee/announcement";
+import { AnnouncementList } from "@/apis/dtos/committee/announcement";
+import { ApiResponseError } from "@/types/common/api";
 import { useQuery } from "@tanstack/react-query";
 
 interface AnnouncementListQueryParams {
@@ -8,7 +10,7 @@ interface AnnouncementListQueryParams {
 }
 
 export const useGetAnnouncementListQuery = ({ page, size, direction }: AnnouncementListQueryParams) => {
-  return useQuery({
+  return useQuery<AnnouncementList, ApiResponseError>({
     queryKey: ["announcementList", page, size, direction],
     queryFn: () => getAnnouncementList(page, size, direction),
     enabled: page >= 0,

--- a/src/hooks/tanstack-query/committee/approve-wait/useGetApproveWaitListQuery.ts
+++ b/src/hooks/tanstack-query/committee/approve-wait/useGetApproveWaitListQuery.ts
@@ -1,4 +1,6 @@
 import { getApproveWaitList } from "@/apis/committee/approve-wait";
+import { ApproveWaitList } from "@/apis/dtos/committee/approve-wait";
+import { ApiResponseError } from "@/types/common/api";
 import { useQuery } from "@tanstack/react-query";
 
 interface ApproveWaitListQueryParams {
@@ -8,7 +10,7 @@ interface ApproveWaitListQueryParams {
 }
 
 export const useGetApproveWaitListQuery = ({ page, size, direction }: ApproveWaitListQueryParams) => {
-  return useQuery({
+  return useQuery<ApproveWaitList, ApiResponseError>({
     queryKey: ["approveWait", page, size, direction],
     queryFn: () => getApproveWaitList(page, size, direction),
     enabled: page >= 0,

--- a/src/hooks/tanstack-query/committee/event/useGetApplyDetail.ts
+++ b/src/hooks/tanstack-query/committee/event/useGetApplyDetail.ts
@@ -1,4 +1,6 @@
 import { getApplyDetail } from "@/apis/committee/apply";
+import { ApplyDetailList } from "@/apis/dtos/committee/apply";
+import { ApiResponseError } from "@/types/common/api";
 import { useQuery } from "@tanstack/react-query";
 
 interface ApplyDetailQueryParams {
@@ -9,7 +11,7 @@ interface ApplyDetailQueryParams {
 }
 
 export const useGetApplyDetailQuery = ({ eventId, page, size, direction = "asc" }: ApplyDetailQueryParams) => {
-  return useQuery({
+  return useQuery<ApplyDetailList, ApiResponseError>({
     queryKey: ["applyDetail", eventId, page, size, direction],
     queryFn: () => getApplyDetail(eventId, page, size, direction),
     enabled: page >= 0 && !!eventId,

--- a/src/hooks/tanstack-query/committee/event/useGetApplyList.ts
+++ b/src/hooks/tanstack-query/committee/event/useGetApplyList.ts
@@ -1,4 +1,6 @@
 import { getEventList } from "@/apis/committee/event";
+import { EventList } from "@/apis/dtos/committee/event";
+import { ApiResponseError } from "@/types/common/api";
 import { useQuery } from "@tanstack/react-query";
 
 interface ApplyListQueryParams {
@@ -8,7 +10,7 @@ interface ApplyListQueryParams {
 }
 
 export const useGetApplyListQuery = ({ page, size, direction }: ApplyListQueryParams) => {
-  return useQuery({
+  return useQuery<EventList, ApiResponseError>({
     queryKey: ["applyList", page, size, direction],
     queryFn: () => getEventList(page, size, direction),
     enabled: page >= 0,

--- a/src/hooks/tanstack-query/committee/event/useGetEventList.ts
+++ b/src/hooks/tanstack-query/committee/event/useGetEventList.ts
@@ -1,4 +1,6 @@
 import { getEventList } from "@/apis/committee/event";
+import { EventList } from "@/apis/dtos/committee/event";
+import { ApiResponseError } from "@/types/common/api";
 import { useQuery } from "@tanstack/react-query";
 
 interface EventListQueryParams {
@@ -8,7 +10,7 @@ interface EventListQueryParams {
 }
 
 export const useGetEventListQuery = ({ page, size, direction }: EventListQueryParams) => {
-  return useQuery({
+  return useQuery<EventList, ApiResponseError>({
     queryKey: ["eventList", page, size, direction],
     queryFn: () => getEventList(page, size, direction),
     enabled: page >= 0,

--- a/src/hooks/tanstack-query/common/my-info/useGetMyInfo.ts
+++ b/src/hooks/tanstack-query/common/my-info/useGetMyInfo.ts
@@ -1,10 +1,9 @@
 import { getMyInfo } from "@/apis/common/my-info";
 import { MyInfo } from "@/apis/dtos/common/my-info";
-import { ApiResponseError } from "@/types/common/api";
 import { useQuery } from "@tanstack/react-query";
 
 export const useGetMyInfo = () => {
-  return useQuery<MyInfo, ApiResponseError>({
+  return useQuery<MyInfo>({
     queryKey: ["myInfo"],
     queryFn: () => getMyInfo(),
   });

--- a/src/hooks/tanstack-query/common/my-info/useGetMyInfo.ts
+++ b/src/hooks/tanstack-query/common/my-info/useGetMyInfo.ts
@@ -1,9 +1,10 @@
 import { getMyInfo } from "@/apis/common/my-info";
 import { MyInfo } from "@/apis/dtos/common/my-info";
+import { ApiResponseError } from "@/types/common/api";
 import { useQuery } from "@tanstack/react-query";
 
 export const useGetMyInfo = () => {
-  return useQuery<MyInfo>({
+  return useQuery<MyInfo, ApiResponseError>({
     queryKey: ["myInfo"],
     queryFn: () => getMyInfo(),
   });

--- a/src/hooks/tanstack-query/common/sign-up/index.ts
+++ b/src/hooks/tanstack-query/common/sign-up/index.ts
@@ -15,14 +15,12 @@ export const useOrganizationsQuery = (type: "학생회" | "위원회" | "값을 
     category = "COMMITTEE";
   }
 
-  const { data: organizations } = useQuery({
+  return useQuery({
     queryKey: ["organizations", type],
     queryFn: () => getOrganizations(category),
     staleTime: 1000 * 60 * 60,
     enabled: type === "학생회" || type === "위원회",
   });
-
-  return organizations;
 };
 
 export const useDepartmentsQuery = (id: number) => {


### PR DESCRIPTION
### 개요

close #92 

### 작업사항

- useOrganizationsQuery 훅의 리턴 값을 useQuery로 변경
- useCommitteeCertification 훅 구현 (로그인 권한이 있는 지 검증하고 로그인 페이지로 이동시켜주는 훅)

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 인증 및 권한 오류 발생 시 사용자에게 알림을 표시하고 관련 페이지로 리디렉션하는 중앙화된 오류 처리 기능이 추가되었습니다.

- **버그 수정**
  - 여러 위원회 관련 목록 및 상세 조회 기능에서 인증/권한 오류에 대한 처리가 개선되었습니다.

- **리팩터**
  - 조직 데이터 조회 방식이 일관성 있게 개선되어, 불필요한 중간 변수 사용이 제거되었습니다.
  - 쿼리의 타입 안정성이 강화되어 데이터와 오류 타입이 명확하게 지정되었습니다.
  - 일부 훅에서 불필요한 네비게이션 및 부수 효과 코드가 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->