### PR TITLE
feat: 가입 승인 거절 기능 추가

### DIFF
--- a/src/apis/committee/approve-wait/index.ts
+++ b/src/apis/committee/approve-wait/index.ts
@@ -13,3 +13,9 @@ export const getApproveWaitList = async (page: number, size: number, direction: 
 export const postApproveWait = async (formData: ApproveWaitRequest) => {
   await https.post("auth/managers/approve", formData);
 };
+
+export const postRejectApproveWait = async (formData: ApproveWaitRequest) => {
+  await https.delete("auth/managers/approve", {
+    data: formData,
+  });
+};

--- a/src/components/page/approve-wait/index.tsx
+++ b/src/components/page/approve-wait/index.tsx
@@ -12,8 +12,17 @@ import { useApproveWaitList } from "@/hooks/committee/approve-wait/useApproveWai
 const cn = classNames.bind(styles);
 
 export default function ApproveWait() {
-  const { approveWaitList, totalElements, currentPage, setPage, itemsPerPage, pagesPerGroup, isLoading, onApprove } =
-    useApproveWaitList();
+  const {
+    approveWaitList,
+    totalElements,
+    currentPage,
+    setPage,
+    itemsPerPage,
+    pagesPerGroup,
+    isLoading,
+    onApprove,
+    onReject,
+  } = useApproveWaitList();
 
   return (
     <div className={cn("container")}>
@@ -82,7 +91,11 @@ export default function ApproveWait() {
                       승인
                     </Txt>
                   </Button>
-                  <Button color="red" className={cn("btn")}>
+                  <Button
+                    color="red"
+                    className={cn("btn")}
+                    onClick={() => onReject({ memberId: approveWait.memberId })}
+                  >
                     <Txt size="h6" color="white">
                       거절
                     </Txt>

--- a/src/hooks/committee/approve-wait/useApproveWaitList.ts
+++ b/src/hooks/committee/approve-wait/useApproveWaitList.ts
@@ -4,6 +4,7 @@ import { useGetApproveWaitListQuery } from "@/hooks/tanstack-query/committee/app
 import { usePostApprove } from "@/hooks/tanstack-query/committee/approve-wait/usePostApprove";
 import { ApiResponseError } from "@/types/common/api";
 import { useCommitteeCertification } from "@/hooks/committee/sign-in/useCommitteeCertification";
+import { usePostRejectApproveWait } from "@/hooks/tanstack-query/committee/approve-wait/usePostRejectApproveWait";
 
 export const useApproveWaitList = () => {
   const { page: currentPage } = useGetPageParams();
@@ -13,6 +14,8 @@ export const useApproveWaitList = () => {
   useCommitteeCertification(isError, error as ApiResponseError);
 
   const { onApprove } = usePostApprove();
+
+  const { onReject } = usePostRejectApproveWait();
 
   const approveWaitList = data?.content || [];
   const totalElements = data?.totalElements || 0;
@@ -26,5 +29,6 @@ export const useApproveWaitList = () => {
     pagesPerGroup,
     isLoading,
     onApprove,
+    onReject,
   };
 };

--- a/src/hooks/tanstack-query/committee/approve-wait/usePostRejectApproveWait.ts
+++ b/src/hooks/tanstack-query/committee/approve-wait/usePostRejectApproveWait.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ApiResponseError } from "@/types/common/api";
+import { useQueryKeys } from "@/hooks/tanstack-query/common/useQueryKeys";
+import { ApproveWaitRequest } from "@/types/committee/approve-wait";
+import { postRejectApproveWait } from "@/apis/committee/approve-wait";
+
+export const usePostRejectApproveWait = () => {
+  const { mutate } = usePostRejectApproveWaitMutate();
+  const queryClient = useQueryClient();
+
+  const approveWaitQueryKeys = useQueryKeys(["approveWait"]);
+
+  const onReject = (formData: ApproveWaitRequest) => {
+    mutate(formData, {
+      onError: (error) => {
+        alert(error.response.data.message || "가입 승인 거절에 실패하였습니다.");
+      },
+      onSuccess: () => {
+        approveWaitQueryKeys.forEach((queryKey) => {
+          queryClient.invalidateQueries({ queryKey });
+        });
+
+        alert("가입 승인 거절이 완료되었습니다.");
+      },
+    });
+  };
+  return {
+    onReject,
+  };
+};
+
+export const usePostRejectApproveWaitMutate = () => {
+  return useMutation<void, ApiResponseError, ApproveWaitRequest>({
+    mutationKey: ["rejectApproveWait"],
+    mutationFn: postRejectApproveWait,
+  });
+};


### PR DESCRIPTION
### 개요

close #80 

### 작업사항

- 가입 승인 거절 api 함수 구현
- 가입 승인 거절 api 관련 tanstack query 커스텀 훅 구현
- 가입 승인 거절 버튼에 api 연결

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 승인 대기 목록에서 각 회원에 대해 '거절' 버튼을 눌러 거절 처리를 할 수 있는 기능이 추가되었습니다.
  - 거절 처리 시 성공 및 실패 알림이 표시되고, 목록이 자동으로 갱신됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->