### PR TITLE
feat: 이벤트 생성 시 제목의 최대 길이 50자로 제한

### DIFF
--- a/src/components/page/committee/CreateEvent/InfoForm/index.module.scss
+++ b/src/components/page/committee/CreateEvent/InfoForm/index.module.scss
@@ -13,6 +13,14 @@
   border-radius: 0 0 1rem 1rem;
 }
 
+.titleInputContainer {
+  @include flexSort(column, null, null, 1rem);
+}
+
+.textLength {
+  margin-left: auto;
+}
+
 .eventTimeContainer {
   @include flexSort(row, space-between, center, null);
 }

--- a/src/components/page/committee/CreateEvent/InfoForm/index.tsx
+++ b/src/components/page/committee/CreateEvent/InfoForm/index.tsx
@@ -7,6 +7,7 @@ import { CreateEventForm } from "@/types/committee/event";
 import DateTimePicker from "@/components/common/DateTimePicker";
 import Button from "@/components/design-system/Button";
 import { Selector } from "@/components/common/Selector";
+import { MAX_TITLE_LENGTH } from "@/constants/committee/create-event";
 
 const cn = classNames.bind(styles);
 
@@ -47,7 +48,14 @@ export default function CreateEventInfoForm({
           label="제목"
           type="text"
           placeholder="이벤트 제목을 입력해주세요."
-        />
+          maxLength={MAX_TITLE_LENGTH}
+          value={formData.title}
+          containerClassName={cn("titleInputContainer")}
+        >
+          <Txt size="small" className={cn("textLength")}>
+            {formData.title.length} / {MAX_TITLE_LENGTH}
+          </Txt>
+        </TextInput>
         <div className={cn("eventTimeContainer")}>
           <div className={cn("eventTimeBox")}>
             <Txt size="small" weight="medium">

--- a/src/constants/committee/create-event/index.ts
+++ b/src/constants/committee/create-event/index.ts
@@ -1,0 +1,1 @@
+export const MAX_TITLE_LENGTH = 50;


### PR DESCRIPTION
### 개요

close #99 

### 작업사항

- 이벤트 생성 시 제목의 최대 길이 50자로 제한

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 이벤트 제목 입력란에 최대 글자 수(50자) 제한이 적용되었습니다.
  - 제목 입력 시 현재 글자 수와 최대 글자 수가 함께 표시되어 입력 상태를 쉽게 확인할 수 있습니다.

- **Style**
  - 제목 입력란과 글자 수 표시 영역의 레이아웃 및 정렬이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->