### PR TITLE
feat: 공지사항 상세 페이지에 공지사항 작성일 표시

### DIFF
--- a/src/components/page/committee/announcement/AnnouncementDetailInfoForm/index.module.scss
+++ b/src/components/page/committee/announcement/AnnouncementDetailInfoForm/index.module.scss
@@ -3,6 +3,7 @@
   padding: 2rem;
   border-radius: 1rem 1rem 0 0;
   border: 0.1rem solid #c1c1c1;
+  @include flexSort(row, space-between, center, null);
 }
 
 .contentContainer {

--- a/src/components/page/committee/announcement/AnnouncementDetailInfoForm/index.tsx
+++ b/src/components/page/committee/announcement/AnnouncementDetailInfoForm/index.tsx
@@ -7,6 +7,7 @@ import Button from "@/components/design-system/Button";
 import { Selector } from "@/components/common/Selector";
 import { LabeledTextarea } from "@/components/common/LabeledTextarea";
 import { AnnouncementDetailForm } from "@/types/committee/announcement";
+import { formatToKoreanTime } from "@/utils/date";
 
 const cn = classNames.bind(styles);
 
@@ -27,6 +28,8 @@ interface AnnouncementDetailFormProps {
   onPutAnnouncement: () => void;
   isPutMode: boolean;
   onClickEditButton: () => void;
+  date: Date;
+  isUpdate: boolean;
 }
 
 export default function AnnouncementDetailInfoForm({
@@ -40,11 +43,16 @@ export default function AnnouncementDetailInfoForm({
   onPutAnnouncement,
   isPutMode,
   onClickEditButton,
+  date,
+  isUpdate,
 }: AnnouncementDetailFormProps) {
   return (
     <div>
       <header className={cn("header")}>
         <Txt weight="medium">공지사항</Txt>
+        <Txt size="small" className={cn("date")}>
+          {`작성일 : ${formatToKoreanTime(date)} ${isUpdate ? "(수정됨)" : ""}`}
+        </Txt>
       </header>
       <div className={cn("contentContainer")}>
         <TextInput

--- a/src/components/page/committee/announcement/index.tsx
+++ b/src/components/page/committee/announcement/index.tsx
@@ -20,6 +20,8 @@ export default function AnnouncementDetail() {
     onPutAnnouncement,
     isPutMode,
     onClickEditButton,
+    date,
+    isUpdate,
   } = useAnnouncementForm();
 
   return (
@@ -38,6 +40,8 @@ export default function AnnouncementDetail() {
         onPutAnnouncement={onPutAnnouncement}
         isPutMode={isPutMode}
         onClickEditButton={onClickEditButton}
+        date={date}
+        isUpdate={isUpdate}
       />
     </div>
   );

--- a/src/hooks/committee/announcement/useAnnouncementForm.ts
+++ b/src/hooks/committee/announcement/useAnnouncementForm.ts
@@ -8,6 +8,7 @@ import { useGetAnnouncementId } from "@/hooks/common/useGetPageAnnouncementId";
 import { usePutAnnouncement } from "@/hooks/tanstack-query/committee/announcement/usePutAnnouncement";
 import { useCommitteeCertification } from "@/hooks/committee/sign-in/useCommitteeCertification";
 import { ApiResponseError } from "@/types/common/api";
+import { getEffectiveDate } from "@/functions/getEffectiveDate";
 
 export const useAnnouncementForm = () => {
   const { announcementId } = useGetAnnouncementId();
@@ -31,6 +32,8 @@ export const useAnnouncementForm = () => {
     },
     participationDepartmentIds: [],
   });
+
+  const { date, isUpdate } = getEffectiveDate(formData.createdAt as Date, formData.updatedAt as Date);
 
   const { onPutAnnouncement: putAnnouncement } = usePutAnnouncement(announcementId);
 
@@ -140,5 +143,7 @@ export const useAnnouncementForm = () => {
     onSelectOrganizations,
     isPutMode,
     onClickEditButton,
+    date,
+    isUpdate,
   };
 };


### PR DESCRIPTION
### 개요

close #97 

### 작업사항

- 공지사항 상세 페이지에 공지사항 작성일 표시

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 공지사항 상세 정보에 생성일이 표시됩니다.
  - 공지사항이 수정된 경우 "(수정됨)" 표시가 함께 노출됩니다.

- **Style**
  - 공지사항 상세 정보 헤더 레이아웃이 플렉스박스로 개선되어 정렬이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->