### PR TITLE
feat: 공지사항 삭제 기능 추가

### DIFF
--- a/src/apis/committee/announcement/index.ts
+++ b/src/apis/committee/announcement/index.ts
@@ -27,3 +27,7 @@ export const putAnnouncement = async ({
 }) => {
   await https.put(`announces/${announcementId}`, formData);
 };
+
+export const deleteAnnouncement = async (announcementId: string) => {
+  await https.delete(`announces/${announcementId}`);
+};

--- a/src/components/page/committee/announcement/AnnouncementDetailInfoForm/index.module.scss
+++ b/src/components/page/committee/announcement/AnnouncementDetailInfoForm/index.module.scss
@@ -45,8 +45,12 @@
   margin-left: auto;
 }
 
+.buttonContainer {
+  @include flexSort(row, null, center, 1rem);
+  margin-left: auto;
+}
+
 .announcementBtn {
   width: fit-content;
   padding: 1.5rem;
-  margin-left: auto;
 }

--- a/src/components/page/committee/announcement/AnnouncementDetailInfoForm/index.tsx
+++ b/src/components/page/committee/announcement/AnnouncementDetailInfoForm/index.tsx
@@ -30,6 +30,7 @@ interface AnnouncementDetailFormProps {
   onClickEditButton: () => void;
   date: Date;
   isUpdate: boolean;
+  onDeleteAnnouncement: () => void;
 }
 
 export default function AnnouncementDetailInfoForm({
@@ -45,6 +46,7 @@ export default function AnnouncementDetailInfoForm({
   onClickEditButton,
   date,
   isUpdate,
+  onDeleteAnnouncement,
 }: AnnouncementDetailFormProps) {
   return (
     <div>
@@ -121,19 +123,26 @@ export default function AnnouncementDetailInfoForm({
             ))}
           </div>
         </div>
-        {isPutMode ? (
-          <Button type="submit" className={cn("announcementBtn")} color="primary" onClick={onPutAnnouncement}>
+        <div className={cn("buttonContainer")}>
+          {isPutMode ? (
+            <Button className={cn("announcementBtn")} color="primary" onClick={onPutAnnouncement}>
+              <Txt size="h6" color="white">
+                수정 완료
+              </Txt>
+            </Button>
+          ) : (
+            <Button className={cn("announcementBtn")} color="primary" onClick={onClickEditButton}>
+              <Txt size="h6" color="white">
+                수정하기
+              </Txt>
+            </Button>
+          )}
+          <Button className={cn("announcementBtn")} color="red" onClick={onDeleteAnnouncement}>
             <Txt size="h6" color="white">
-              수정 완료
+              삭제 하기
             </Txt>
           </Button>
-        ) : (
-          <Button type="submit" className={cn("announcementBtn")} color="primary" onClick={onClickEditButton}>
-            <Txt size="h6" color="white">
-              수정하기
-            </Txt>
-          </Button>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/page/committee/announcement/index.tsx
+++ b/src/components/page/committee/announcement/index.tsx
@@ -22,6 +22,7 @@ export default function AnnouncementDetail() {
     onClickEditButton,
     date,
     isUpdate,
+    onDeleteAnnouncement,
   } = useAnnouncementForm();
 
   return (
@@ -42,6 +43,7 @@ export default function AnnouncementDetail() {
         onClickEditButton={onClickEditButton}
         date={date}
         isUpdate={isUpdate}
+        onDeleteAnnouncement={onDeleteAnnouncement}
       />
     </div>
   );

--- a/src/hooks/committee/announcement/useAnnouncementForm.ts
+++ b/src/hooks/committee/announcement/useAnnouncementForm.ts
@@ -9,6 +9,7 @@ import { usePutAnnouncement } from "@/hooks/tanstack-query/committee/announcemen
 import { useCommitteeCertification } from "@/hooks/committee/sign-in/useCommitteeCertification";
 import { ApiResponseError } from "@/types/common/api";
 import { getEffectiveDate } from "@/functions/getEffectiveDate";
+import { useDeleteAnnouncement } from "@/hooks/tanstack-query/committee/announcement/useDeleteAnnouncement";
 
 export const useAnnouncementForm = () => {
   const { announcementId } = useGetAnnouncementId();
@@ -36,6 +37,8 @@ export const useAnnouncementForm = () => {
   const { date, isUpdate } = getEffectiveDate(formData.createdAt as Date, formData.updatedAt as Date);
 
   const { onPutAnnouncement: putAnnouncement } = usePutAnnouncement(announcementId);
+
+  const { onDeleteAnnouncement: deleteAnnouncement } = useDeleteAnnouncement();
 
   let { data: organizations } = useOrganizationsQuery("학생회");
 
@@ -128,6 +131,12 @@ export const useAnnouncementForm = () => {
     setIsPutMode(false);
   };
 
+  const onDeleteAnnouncement = () => {
+    if (confirm("정말로 공지사항을 삭제하시겠습니까?")) {
+      deleteAnnouncement(announcementId);
+    }
+  };
+
   const onClickEditButton = () => {
     setIsPutMode(true);
   };
@@ -145,5 +154,6 @@ export const useAnnouncementForm = () => {
     onClickEditButton,
     date,
     isUpdate,
+    onDeleteAnnouncement,
   };
 };

--- a/src/hooks/tanstack-query/committee/announcement/useCreateAnnouncement.ts
+++ b/src/hooks/tanstack-query/committee/announcement/useCreateAnnouncement.ts
@@ -11,7 +11,7 @@ export const useCreateAnnouncement = () => {
   const { mutate } = useCreateAnnouncementMutate();
   const queryClient = useQueryClient();
 
-  const eventQueryKeys = useQueryKeys(["announcementList"]);
+  const announcementQueryKeys = useQueryKeys(["announcementList"]);
 
   const onCreateAnnouncement = (formData: CreateAnnouncementFormRequest) => {
     mutate(formData, {
@@ -19,7 +19,7 @@ export const useCreateAnnouncement = () => {
         alert(error.response.data.message || "공지사항 생성에 실패하였습니다.");
       },
       onSuccess: () => {
-        eventQueryKeys.forEach((queryKey) => {
+        announcementQueryKeys.forEach((queryKey) => {
           queryClient.invalidateQueries({ queryKey });
         });
 

--- a/src/hooks/tanstack-query/committee/announcement/useCreateAnnouncement.ts
+++ b/src/hooks/tanstack-query/committee/announcement/useCreateAnnouncement.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { ROUTE } from "@/constants/routes";
 import { ApiResponseError } from "@/types/common/api";
-import { useQueryKeys } from "../../common/useQueryKeys";
+import { useQueryKeys } from "@/hooks/tanstack-query/common/useQueryKeys";
 import { CreateAnnouncementFormRequest } from "@/types/committee/announcement";
 import { postCreateAnnouncement } from "@/apis/committee/announcement";
 

--- a/src/hooks/tanstack-query/committee/announcement/useDeleteAnnouncement.ts
+++ b/src/hooks/tanstack-query/committee/announcement/useDeleteAnnouncement.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ApiResponseError } from "@/types/common/api";
+import { deleteAnnouncement } from "@/apis/committee/announcement";
+import { useRouter } from "next/navigation";
+import { ROUTE } from "@/constants/routes";
+import { useQueryKeys } from "../../common/useQueryKeys";
+
+export const useDeleteAnnouncement = () => {
+  const { mutate } = useDeleteAnnouncementMutate();
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const announcementQueryKeys = useQueryKeys(["announcementList"]);
+
+  const onDeleteAnnouncement = (announcementId: string) => {
+    mutate(announcementId, {
+      onError: (error) => {
+        alert(error.response.data.message || "공지사항 삭제에 실패하였습니다.");
+      },
+      onSuccess: () => {
+        announcementQueryKeys.forEach((queryKey) => {
+          queryClient.invalidateQueries({ queryKey });
+        });
+        router.push(ROUTE.COMMITTEE.ANNOUNCEMENT_LIST);
+        alert("공지사항 삭제에 성공하셨습니다.");
+      },
+    });
+  };
+  return {
+    onDeleteAnnouncement,
+  };
+};
+
+export const useDeleteAnnouncementMutate = () => {
+  return useMutation<void, ApiResponseError, string>({
+    mutationKey: ["deleteAnnouncement"],
+    mutationFn: deleteAnnouncement,
+  });
+};

--- a/src/hooks/tanstack-query/committee/announcement/useDeleteAnnouncement.ts
+++ b/src/hooks/tanstack-query/committee/announcement/useDeleteAnnouncement.ts
@@ -3,7 +3,7 @@ import { ApiResponseError } from "@/types/common/api";
 import { deleteAnnouncement } from "@/apis/committee/announcement";
 import { useRouter } from "next/navigation";
 import { ROUTE } from "@/constants/routes";
-import { useQueryKeys } from "../../common/useQueryKeys";
+import { useQueryKeys } from "@/hooks/tanstack-query/common/useQueryKeys";
 
 export const useDeleteAnnouncement = () => {
   const { mutate } = useDeleteAnnouncementMutate();

--- a/src/hooks/tanstack-query/committee/event/useCreateEvent.ts
+++ b/src/hooks/tanstack-query/committee/event/useCreateEvent.ts
@@ -4,7 +4,7 @@ import { ROUTE } from "@/constants/routes";
 import { postCreateEvent } from "@/apis/committee/event";
 import { CreateEventRequest } from "@/types/committee/event";
 import { ApiResponseError } from "@/types/common/api";
-import { useQueryKeys } from "../../common/useQueryKeys";
+import { useQueryKeys } from "@/hooks/tanstack-query/common/useQueryKeys";
 
 export const useCreateEvent = () => {
   const router = useRouter();


### PR DESCRIPTION
### 개요

close #96 

### 작업사항

- 공지사항 삭제 api 함수 구현
- 공지사항 삭제 api 관련 tanstack query 커스텀 훅 구현
- 공지사항 삭제 버튼에 삭제 api 연동

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 공지사항을 삭제할 수 있는 기능이 추가되었습니다. 상세 정보 화면에 "삭제 하기" 버튼이 노출되며, 삭제 시 확인 창이 표시됩니다.
- **스타일**
    - 버튼 정렬을 위한 스타일이 개선되었습니다.
- **리팩터**
    - 일부 내부 네이밍 및 import 경로가 일관성 있게 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->