### PR TITLE
feat: 사물함 신청 시 존재하지 않는 층 번호에 대한 validation 추가

### DIFF
--- a/src/hooks/tanstack-query/student/apply-locker/usePostApplyLocker.ts
+++ b/src/hooks/tanstack-query/student/apply-locker/usePostApplyLocker.ts
@@ -10,6 +10,12 @@ export const usePostApplyLocker = () => {
   const onApplyLocker = (eventId: string, lockerName: string, floor: number) => {
     const lockerListData: LockerList[] | undefined = queryClient.getQueryData(["lockerList", eventId]);
 
+    const lockerFloor = lockerListData?.find((locker) => locker.floorNumber === floor);
+    if (!lockerFloor) {
+      alert("유효하지 않은 층수입니다.");
+      return;
+    }
+
     const lockerId = lockerListData
       ?.find((locker) => locker.floorNumber === floor)
       ?.lockerList.find((locker) => locker.code === lockerName)?.lockerId;

--- a/src/hooks/tanstack-query/student/apply-locker/usePostApplyLocker.ts
+++ b/src/hooks/tanstack-query/student/apply-locker/usePostApplyLocker.ts
@@ -16,9 +16,7 @@ export const usePostApplyLocker = () => {
       return;
     }
 
-    const lockerId = lockerListData
-      ?.find((locker) => locker.floorNumber === floor)
-      ?.lockerList.find((locker) => locker.code === lockerName)?.lockerId;
+    const lockerId = lockerFloor.lockerList.find((locker) => locker.code === lockerName)?.lockerId;
 
     if (lockerId === undefined) {
       alert("유효하지 않은 사물함 이름입니다.");


### PR DESCRIPTION
### 개요

close #73 

### 작업사항

- 사물함 신청 시 존재하지 않는 층 번호에 대한 validation 추가

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 존재하지 않는 층수를 입력할 경우 "유효하지 않은 층수입니다."라는 안내 메시지가 표시되며, 신청이 중단됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->