### PR TITLE
feat: 이벤트 상세 페이지 구현

### DIFF
--- a/src/apis/committee/event/index.ts
+++ b/src/apis/committee/event/index.ts
@@ -1,6 +1,6 @@
-import { EventList } from "@/apis/dtos/committee/event";
+import { EventDetail, EventList } from "@/apis/dtos/committee/event";
 import { https } from "@/apis/instance/https";
-import { CreateEventRequest } from "@/types/committee/event";
+import { CreateEventRequest, PutEventRequest } from "@/types/committee/event";
 
 export const postCreateEvent = async (formData: CreateEventRequest) => {
   await https.post("events", formData);
@@ -25,4 +25,14 @@ export const putEventPublish = async ({ id, isPublish }: PutEventPublishParam) =
   await https.put(`events/${id}/publish`, {
     isPublish,
   });
+};
+
+export const getEvent = async (eventId: string) => {
+  const { data } = await https.get(`events/${eventId}`);
+
+  return new EventDetail(data);
+};
+
+export const putEvent = async ({ formData, eventId }: { formData: PutEventRequest; eventId: string }) => {
+  await https.put(`events/${eventId}`, formData);
 };

--- a/src/apis/dtos/committee/event/index.ts
+++ b/src/apis/dtos/committee/event/index.ts
@@ -41,3 +41,85 @@ export class EventList {
     this.isLast = last;
   }
 }
+
+export class EventDetail {
+  id: string;
+  title: string;
+  participationDepartmentIds: {
+    id: number;
+    value: string;
+  }[];
+  startAt: Date;
+  endAt: Date;
+  status: "READY" | "OPEN" | "CLOSED";
+  publish: boolean;
+  floors: {
+    floorId: number;
+    floorNumber: number;
+    prefixes: {
+      prefixId: string;
+      lockerPrefix: string;
+      ranges: {
+        rangeId: number;
+        lockerStartNumber: number;
+        lockerEndNumber: number;
+      }[];
+    }[];
+  }[];
+
+  constructor({
+    id,
+    title,
+    participationDepartments,
+    startAt,
+    endAt,
+    status,
+    publish,
+    floors,
+  }: {
+    id: string;
+    title: string;
+    participationDepartments: {
+      id: number;
+      name: string;
+    }[];
+    startAt: Date;
+    endAt: Date;
+    status: "READY" | "OPEN" | "CLOSED";
+    publish: boolean;
+    floors: {
+      floorNumber: number;
+      prefixes: {
+        lockerPrefix: string;
+        ranges: {
+          lockerStartNumber: number;
+          lockerEndNumber: number;
+        }[];
+      }[];
+    }[];
+  }) {
+    this.id = id;
+    this.title = title;
+    this.participationDepartmentIds = participationDepartments.map((department) => ({
+      id: department.id,
+      value: department.name,
+    }));
+    this.startAt = startAt;
+    this.endAt = endAt;
+    this.status = status;
+    this.publish = publish;
+    this.floors = floors.map((floor) => ({
+      floorId: floor.floorNumber,
+      floorNumber: floor.floorNumber,
+      prefixes: floor.prefixes.map((prefix) => ({
+        prefixId: prefix.lockerPrefix,
+        lockerPrefix: prefix.lockerPrefix,
+        ranges: prefix.ranges.map((range) => ({
+          rangeId: range.lockerStartNumber,
+          lockerStartNumber: range.lockerStartNumber,
+          lockerEndNumber: range.lockerEndNumber,
+        })),
+      })),
+    }));
+  }
+}

--- a/src/app/committee/event/[eventId]/page.tsx
+++ b/src/app/committee/event/[eventId]/page.tsx
@@ -1,0 +1,11 @@
+import CommitteeHeader from "@/components/common/CommitteeHeader";
+import EventDetail from "@/components/page/committee/event-detail";
+
+export default function EventDetailPage() {
+  return (
+    <>
+      <CommitteeHeader />
+      <EventDetail />
+    </>
+  );
+}

--- a/src/components/page/committee/event-detail/EventDetailDateTimePicker/DateTimePicker.css
+++ b/src/components/page/committee/event-detail/EventDetailDateTimePicker/DateTimePicker.css
@@ -1,0 +1,62 @@
+.react-datepicker {
+  border: 0;
+  box-shadow: 0 0.4rem 0.8rem 0 #00000040;
+  border-radius: 1rem;
+  font-size: 1.6rem;
+  height: 21rem;
+}
+
+.react-datepicker__navigation {
+  right: 12rem !important;
+}
+
+.react-datepicker__month-container {
+  width: 80%;
+  height: 100%;
+}
+
+.react-datepicker__current-month {
+  font-size: 2rem;
+}
+
+.react-datepicker__day--selected {
+  background-color: #0bb964;
+  color: #fff;
+  padding: 0.5rem;
+}
+
+.react-datepicker__day-name {
+  width: 4rem;
+  line-height: 2rem;
+  margin: 0.166rem;
+  color: #0bb964 !important;
+}
+
+.react-datepicker__day {
+  width: 4rem;
+  line-height: 2.5rem;
+  margin: 0.166rem;
+}
+
+.react-datepicker__time-container {
+  width: 20%;
+}
+
+.react-datepicker__header {
+  height: 5.2rem;
+}
+
+.react-datepicker-time__header {
+  font-size: 2rem;
+}
+
+.react-datepicker__time-box {
+  width: 100% !important;
+}
+
+.react-datepicker__time-list-item {
+  height: 4rem !important;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/components/page/committee/event-detail/EventDetailDateTimePicker/index.module.scss
+++ b/src/components/page/committee/event-detail/EventDetailDateTimePicker/index.module.scss
@@ -1,0 +1,3 @@
+.container {
+  @include flexSort(column, null, null, 3rem);
+}

--- a/src/components/page/committee/event-detail/EventDetailDateTimePicker/index.tsx
+++ b/src/components/page/committee/event-detail/EventDetailDateTimePicker/index.tsx
@@ -1,0 +1,57 @@
+import Txt from "@/components/design-system/Txt";
+import DatePicker from "react-datepicker";
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import "./DateTimePicker.css";
+import { useCallback } from "react";
+import { EventDetailForm } from "@/types/committee/event";
+import { getDate, getHours, getMinutes, getMonth, getYear } from "@/functions/date";
+
+const cn = classNames.bind(styles);
+
+interface EventDetailDateTimePickerProps {
+  data: EventDetailForm;
+  setData: (formData: EventDetailForm) => void;
+  type: "startAt" | "endAt";
+  isPutMode: boolean;
+}
+
+export default function EventDetailDateTimePicker({ data, setData, type, isPutMode }: EventDetailDateTimePickerProps) {
+  const date = type === "startAt" ? data.startAt : data.endAt;
+
+  const selectedYear = date ? getYear(date) : 0;
+  const selectedMonth = date ? getMonth(date) : "00";
+  const selectedDay = date ? getDate(date) : "00";
+  const selectedHour = date ? getHours(date) : "00";
+  const selectedMinute = date ? getMinutes(date) : "00";
+
+  const handleDateChange = useCallback(
+    (newDate: Date | null) => {
+      if (!newDate) return;
+
+      if (type === "startAt" && data.endAt && newDate > data.endAt) {
+        alert("시작 시간은 종료 시간보다 이전이어야 합니다.");
+        return;
+      }
+
+      if (type === "endAt" && data.startAt && newDate < data.startAt) {
+        alert("종료 시간은 시작 시간보다 이후여야 합니다.");
+        return;
+      }
+
+      setData({ ...data, [type]: newDate });
+    },
+    [data, setData, type],
+  );
+
+  return (
+    <div className={cn("container")}>
+      <Txt size="h3" color="black">
+        {`${selectedYear} : ${selectedMonth} : ${selectedDay} / ${selectedHour} : ${selectedMinute}`}
+      </Txt>
+      {isPutMode && (
+        <DatePicker selected={date instanceof Date ? date : null} onChange={handleDateChange} showTimeSelect inline />
+      )}
+    </div>
+  );
+}

--- a/src/components/page/committee/event-detail/FloorInfoForm/index.module.scss
+++ b/src/components/page/committee/event-detail/FloorInfoForm/index.module.scss
@@ -1,0 +1,26 @@
+.container {
+  border: 0.1rem solid #c1c1c1;
+  padding: 2rem;
+  border-radius: 1rem;
+  @include flexSort(column, null, null, 3rem);
+}
+
+.floorTitle,
+.prefixTitle {
+  @include flexSort(row, space-between, center, null);
+}
+
+.deleteFloorBtn {
+  width: fit-content;
+  padding: 1rem 1.5rem;
+  margin-left: auto;
+}
+
+.prefixContainer {
+  @include flexSort(column, null, null, 2rem);
+}
+
+.addPrefixBtn {
+  width: fit-content;
+  padding: 1rem 1.5rem;
+}

--- a/src/components/page/committee/event-detail/FloorInfoForm/index.tsx
+++ b/src/components/page/committee/event-detail/FloorInfoForm/index.tsx
@@ -1,0 +1,101 @@
+import Txt from "@/components/design-system/Txt";
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import TextInput from "@/components/common/TextInput";
+import "react-datepicker/dist/react-datepicker.css";
+import { EventDetailForm } from "@/types/committee/event";
+import Button from "@/components/design-system/Button";
+import EventDetailPrefixInfoForm from "@/components/page/committee/event-detail/PrefixInfoForm/index";
+
+const cn = classNames.bind(styles);
+
+interface EventDetailFloorInfoFormProps {
+  floorData: EventDetailForm["floors"][number];
+  onChangeFloorNumber: (floorId: number, floorNumber: number) => void;
+  onAddPrefix: (floorId: number) => void;
+  onChangePrefix: (floorId: number, prefixId: number, lockerPrefix: string) => void;
+  onAddRange: (floorId: number, prefixId: number) => void;
+  onChangeRange: (
+    floorId: number,
+    prefixId: number,
+    rangeId: number,
+    type: "start" | "end",
+    lockerNumber: number | null,
+  ) => void;
+  onDeleteFloor: (floorId: number) => void;
+  onDeletePrefix: (floorId: number, prefixId: number) => void;
+  onDeleteRange: (floorId: number, prefixId: number, rangeId: number) => void;
+  isPutMode: boolean;
+}
+
+export default function EventDetailFloorInfoForm({
+  floorData,
+  onChangeFloorNumber,
+  onAddPrefix,
+  onChangePrefix,
+  onAddRange,
+  onChangeRange,
+  onDeleteFloor,
+  onDeletePrefix,
+  onDeleteRange,
+  isPutMode,
+}: EventDetailFloorInfoFormProps) {
+  return (
+    <div className={cn("container")}>
+      <div className={cn("floorTitle")}>
+        <Txt size="h5" weight="medium">
+          층
+        </Txt>
+        {isPutMode && (
+          <Button className={cn("deleteFloorBtn")} color="red" onClick={() => onDeleteFloor(floorData.floorId)}>
+            <Txt size="h6" color="white">
+              층 삭제
+            </Txt>
+          </Button>
+        )}
+      </div>
+      <TextInput
+        label="층수"
+        value={floorData.floorNumber ?? 0}
+        id="floorNumber"
+        type="text"
+        readOnly={!isPutMode}
+        placeholder="숫자로 입력해주세요. (예: 2)"
+        onChange={(e) => {
+          const value = e.target.value;
+          const numberValue = Number(value);
+          if (!isNaN(numberValue)) {
+            onChangeFloorNumber(floorData.floorId, numberValue);
+          }
+        }}
+      />
+      <div className={cn("prefixContainer")}>
+        <div className={cn("prefixTitle")}>
+          <Txt size="h5" weight="medium">
+            접두사
+          </Txt>
+          {isPutMode && (
+            <Button className={cn("addPrefixBtn")} color="blue" onClick={() => onAddPrefix(floorData.floorId)}>
+              <Txt size="h6" color="white">
+                + 접두사 추가
+              </Txt>
+            </Button>
+          )}
+        </div>
+        {floorData.prefixes.map((prefix) => (
+          <EventDetailPrefixInfoForm
+            floorId={floorData.floorId}
+            key={prefix.prefixId}
+            prefixData={prefix}
+            onChangePrefix={onChangePrefix}
+            onAddRange={onAddRange}
+            onChangeRange={onChangeRange}
+            onDeletePrefix={onDeletePrefix}
+            onDeleteRange={onDeleteRange}
+            isPutMode={isPutMode}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/page/committee/event-detail/FloorInfoForm/index.tsx
+++ b/src/components/page/committee/event-detail/FloorInfoForm/index.tsx
@@ -13,18 +13,18 @@ interface EventDetailFloorInfoFormProps {
   floorData: EventDetailForm["floors"][number];
   onChangeFloorNumber: (floorId: number, floorNumber: number) => void;
   onAddPrefix: (floorId: number) => void;
-  onChangePrefix: (floorId: number, prefixId: number, lockerPrefix: string) => void;
-  onAddRange: (floorId: number, prefixId: number) => void;
+  onChangePrefix: (floorId: number, prefixId: number | string, lockerPrefix: string) => void;
+  onAddRange: (floorId: number, prefixId: number | string) => void;
   onChangeRange: (
     floorId: number,
-    prefixId: number,
+    prefixId: number | string,
     rangeId: number,
     type: "start" | "end",
     lockerNumber: number | null,
   ) => void;
   onDeleteFloor: (floorId: number) => void;
-  onDeletePrefix: (floorId: number, prefixId: number) => void;
-  onDeleteRange: (floorId: number, prefixId: number, rangeId: number) => void;
+  onDeletePrefix: (floorId: number, prefixId: number | string) => void;
+  onDeleteRange: (floorId: number, prefixId: number | string, rangeId: number) => void;
   isPutMode: boolean;
 }
 

--- a/src/components/page/committee/event-detail/InfoForm/index.module.scss
+++ b/src/components/page/committee/event-detail/InfoForm/index.module.scss
@@ -1,0 +1,58 @@
+.header {
+  background-color: #f9f9f9;
+  padding: 2rem;
+  border-radius: 1rem 1rem 0 0;
+  border: 0.1rem solid #c1c1c1;
+}
+
+.contentContainer {
+  padding: 2rem;
+  border: 0.1rem solid #c1c1c1;
+  border-top: 0rem;
+  @include flexSort(column, null, null, 2rem);
+  border-radius: 0 0 1rem 1rem;
+}
+
+.titleInputContainer {
+  @include flexSort(column, null, null, 1rem);
+}
+
+.textLength {
+  margin-left: auto;
+}
+
+.eventTimeContainer {
+  @include flexSort(row, space-between, center, null);
+}
+
+.eventTimeBox {
+  width: 60rem;
+  @include flexSort(column, null, null, 1rem);
+}
+
+.participationDepartmentSelectorContainer {
+  @include flexSort(row, space-between, center, 2rem);
+}
+
+.selectDepartmentContainer {
+  @include flexSort(column, null, null, 1rem);
+}
+
+.selectedDepartmentContainer {
+  @include flexSort(column, null, null, 1rem);
+}
+
+.selectedDepartment {
+  @include flexSort(row, center, center, 1rem);
+  padding: 1rem 2rem;
+  border-radius: 1rem;
+  background-color: #f9f9f9;
+  border: 0.1rem solid #c1c1c1;
+  width: fit-content;
+}
+
+.deleteDepartmentBtn {
+  width: fit-content;
+  padding: 0.5rem 1rem;
+  margin-left: auto;
+}

--- a/src/components/page/committee/event-detail/InfoForm/index.tsx
+++ b/src/components/page/committee/event-detail/InfoForm/index.tsx
@@ -1,0 +1,127 @@
+import Txt from "@/components/design-system/Txt";
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import TextInput from "@/components/common/TextInput";
+import "react-datepicker/dist/react-datepicker.css";
+import { EventDetailForm } from "@/types/committee/event";
+import Button from "@/components/design-system/Button";
+import { Selector } from "@/components/common/Selector";
+import { MAX_EVENT_TITLE_LENGTH } from "@/constants/committee/create-event";
+import EventDetailDateTimePicker from "@/components/page/committee/event-detail/EventDetailDateTimePicker";
+
+const cn = classNames.bind(styles);
+
+interface EventDetailInfoFormProps {
+  formData: EventDetailForm;
+  setFormData: (formData: EventDetailForm) => void;
+  organizations: {
+    id: number;
+    value: string;
+  }[];
+  departments: {
+    id: number;
+    value: string;
+  }[];
+  onDeleteDepartment: (id: number) => void;
+  onSelectDepartment: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  onSelectOrganizations: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  isPutMode: boolean;
+}
+
+export default function EventDetailInfoForm({
+  formData,
+  setFormData,
+  organizations,
+  departments,
+  onDeleteDepartment,
+  onSelectOrganizations,
+  onSelectDepartment,
+  isPutMode,
+}: EventDetailInfoFormProps) {
+  return (
+    <div>
+      <header className={cn("header")}>
+        <Txt weight="medium">기본 정보</Txt>
+      </header>
+      <div className={cn("contentContainer")}>
+        <TextInput
+          id="title"
+          onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+          label="제목"
+          type="text"
+          placeholder="이벤트 제목을 입력해주세요."
+          maxLength={MAX_EVENT_TITLE_LENGTH}
+          value={formData.title}
+          containerClassName={cn("titleInputContainer")}
+          readOnly={!isPutMode}
+        >
+          <Txt size="small" className={cn("textLength")}>
+            {formData.title.length} / {MAX_EVENT_TITLE_LENGTH}
+          </Txt>
+        </TextInput>
+        <div className={cn("eventTimeContainer")}>
+          <div className={cn("eventTimeBox")}>
+            <Txt size="small" weight="medium">
+              생성 시작 시간
+            </Txt>
+            <EventDetailDateTimePicker data={formData} type="startAt" setData={setFormData} isPutMode={isPutMode} />
+          </div>
+          <div className={cn("eventTimeBox")}>
+            <Txt size="small" weight="medium">
+              생성 마감 시간
+            </Txt>
+            <EventDetailDateTimePicker data={formData} type="endAt" setData={setFormData} isPutMode={isPutMode} />
+          </div>
+        </div>
+        {isPutMode && (
+          <>
+            <Txt size="h5" weight="medium">
+              사물함 신청 참여 학과
+            </Txt>
+            <div className={cn("participationDepartmentSelectorContainer")}>
+              <Selector
+                label="소속"
+                onChange={onSelectOrganizations}
+                options={organizations}
+                value={formData.affiliation.value}
+                id="affiliation"
+              />
+              <Selector
+                label="학과"
+                onChange={onSelectDepartment}
+                options={departments}
+                value={departments[0].value}
+                id="department"
+              />
+            </div>
+          </>
+        )}
+        <div className={cn("selectDepartmentContainer")}>
+          <Txt size="h5" weight="medium">
+            선택한 참여 학과
+          </Txt>
+          <div className={cn("selectedDepartmentContainer")}>
+            {formData.participationDepartmentIds.map((department) => (
+              <div key={department.id} className={cn("selectedDepartment")}>
+                <Txt size="small" weight="medium">
+                  {department.value}
+                </Txt>
+                {isPutMode && (
+                  <Button
+                    className={cn("deleteDepartmentBtn")}
+                    color="red"
+                    onClick={() => onDeleteDepartment(department.id)}
+                  >
+                    <Txt size="small" color="white">
+                      삭제
+                    </Txt>
+                  </Button>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/page/committee/event-detail/LockerInfoForm/index.module.scss
+++ b/src/components/page/committee/event-detail/LockerInfoForm/index.module.scss
@@ -1,0 +1,25 @@
+.header {
+  background-color: #f9f9f9;
+  padding: 2rem;
+  border-radius: 1rem 1rem 0 0;
+  border: 0.1rem solid #c1c1c1;
+}
+
+.floorContainer {
+  padding: 3rem;
+  border: 0.1rem solid #c1c1c1;
+  border-radius: 0 0 1rem 1rem;
+  border-top: 0;
+  @include flexSort(column, null, null, 3rem);
+}
+
+.addFloorBtn {
+  width: fit-content;
+  padding: 1rem 1.5rem;
+}
+
+.createEventBtn {
+  width: fit-content;
+  padding: 1.5rem;
+  margin-left: auto;
+}

--- a/src/components/page/committee/event-detail/LockerInfoForm/index.tsx
+++ b/src/components/page/committee/event-detail/LockerInfoForm/index.tsx
@@ -1,0 +1,86 @@
+import Txt from "@/components/design-system/Txt";
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import "react-datepicker/dist/react-datepicker.css";
+import { EventDetailForm } from "@/types/committee/event";
+import Button from "@/components/design-system/Button";
+import EventDetailFloorInfoForm from "../FloorInfoForm";
+
+const cn = classNames.bind(styles);
+
+interface EventDetailLockerInfoFormProps {
+  formData: EventDetailForm;
+  onAddFloor: () => void;
+  onChangeFloorNumber: (floorId: number, floorNumber: number) => void;
+  onAddPrefix: (floorId: number) => void;
+  onChangePrefix: (floorId: number, prefixId: number, lockerPrefix: string) => void;
+  onAddRange: (floorId: number, prefixId: number) => void;
+  onChangeRange: (
+    floorId: number,
+    prefixId: number,
+    rangeId: number,
+    type: "start" | "end",
+    lockerNumber: number | null,
+  ) => void;
+  onDeleteFloor: (floorId: number) => void;
+  onDeletePrefix: (floorId: number, prefixId: number) => void;
+  onDeleteRange: (floorId: number, prefixId: number, rangeId: number) => void;
+  onPutEvent: () => void;
+  isPutMode: boolean;
+  onPutClick: () => void;
+}
+
+export default function EventDetailLockerInfoForm({
+  formData,
+  onAddFloor,
+  onChangeFloorNumber,
+  onAddPrefix,
+  onChangePrefix,
+  onAddRange,
+  onChangeRange,
+  onDeleteFloor,
+  onDeletePrefix,
+  onDeleteRange,
+  onPutEvent,
+  isPutMode,
+  onPutClick,
+}: EventDetailLockerInfoFormProps) {
+  return (
+    <>
+      <div>
+        <header className={cn("header")}>
+          <Txt weight="medium">층수 정보</Txt>
+        </header>
+        <div className={cn("floorContainer")}>
+          {formData.floors.map((floor) => (
+            <EventDetailFloorInfoForm
+              floorData={floor}
+              key={floor.floorId}
+              onChangeFloorNumber={onChangeFloorNumber}
+              onAddPrefix={onAddPrefix}
+              onChangePrefix={onChangePrefix}
+              onAddRange={onAddRange}
+              onChangeRange={onChangeRange}
+              onDeleteFloor={onDeleteFloor}
+              onDeletePrefix={onDeletePrefix}
+              onDeleteRange={onDeleteRange}
+              isPutMode={isPutMode}
+            />
+          ))}
+        </div>
+      </div>
+      {isPutMode && (
+        <Button className={cn("addFloorBtn")} color="blue" onClick={onAddFloor}>
+          <Txt size="h6" color="white">
+            + 층 추가
+          </Txt>
+        </Button>
+      )}
+      <Button className={cn("createEventBtn")} color="primary" onClick={isPutMode ? onPutEvent : onPutClick}>
+        <Txt size="h6" color="white">
+          {isPutMode ? "수정 완료" : "수정 하기"}
+        </Txt>
+      </Button>
+    </>
+  );
+}

--- a/src/components/page/committee/event-detail/LockerInfoForm/index.tsx
+++ b/src/components/page/committee/event-detail/LockerInfoForm/index.tsx
@@ -13,18 +13,18 @@ interface EventDetailLockerInfoFormProps {
   onAddFloor: () => void;
   onChangeFloorNumber: (floorId: number, floorNumber: number) => void;
   onAddPrefix: (floorId: number) => void;
-  onChangePrefix: (floorId: number, prefixId: number, lockerPrefix: string) => void;
-  onAddRange: (floorId: number, prefixId: number) => void;
+  onChangePrefix: (floorId: number, prefixId: number | string, lockerPrefix: string) => void;
+  onAddRange: (floorId: number, prefixId: number | string) => void;
   onChangeRange: (
     floorId: number,
-    prefixId: number,
+    prefixId: number | string,
     rangeId: number,
     type: "start" | "end",
     lockerNumber: number | null,
   ) => void;
   onDeleteFloor: (floorId: number) => void;
-  onDeletePrefix: (floorId: number, prefixId: number) => void;
-  onDeleteRange: (floorId: number, prefixId: number, rangeId: number) => void;
+  onDeletePrefix: (floorId: number, prefixId: number | string) => void;
+  onDeleteRange: (floorId: number, prefixId: number | string, rangeId: number) => void;
   onPutEvent: () => void;
   isPutMode: boolean;
   onPutClick: () => void;

--- a/src/components/page/committee/event-detail/PrefixInfoForm/index.module.scss
+++ b/src/components/page/committee/event-detail/PrefixInfoForm/index.module.scss
@@ -1,0 +1,26 @@
+.container {
+  border: 0.1rem solid #c1c1c1;
+  border-radius: 1rem;
+  padding: 2rem;
+  @include flexSort(column, null, null, 3rem);
+  background-color: #f9f9f9;
+}
+
+.deletePrefixBtn {
+  width: fit-content;
+  padding: 1rem 1.5rem;
+  margin-left: auto;
+}
+
+.rangeContainer {
+  @include flexSort(column, null, null, 2rem);
+}
+
+.rangeTitle {
+  @include flexSort(row, space-between, center, null);
+}
+
+.addRangeBtn {
+  width: fit-content;
+  padding: 1rem 1.5rem;
+}

--- a/src/components/page/committee/event-detail/PrefixInfoForm/index.tsx
+++ b/src/components/page/committee/event-detail/PrefixInfoForm/index.tsx
@@ -1,0 +1,91 @@
+import Txt from "@/components/design-system/Txt";
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import TextInput from "@/components/common/TextInput";
+import "react-datepicker/dist/react-datepicker.css";
+import { EventDetailForm } from "@/types/committee/event";
+import Button from "@/components/design-system/Button";
+import EventDetailRangeInfoForm from "../RangeInfoForm";
+
+const cn = classNames.bind(styles);
+
+interface EventDetailPrefixInfoFormProps {
+  floorId: number;
+  prefixData: EventDetailForm["floors"][number]["prefixes"][number];
+  onChangePrefix: (floorId: number, prefixId: number | string, lockerPrefix: string) => void;
+  onAddRange: (floorId: number, prefixId: number | string) => void;
+  onChangeRange: (
+    floorId: number,
+    prefixId: number | string,
+    rangeId: number,
+    type: "start" | "end",
+    lockerNumber: number | null,
+  ) => void;
+  onDeletePrefix: (floorId: number, prefixId: number | string) => void;
+  onDeleteRange: (floorId: number, prefixId: number | string, rangeId: number) => void;
+  isPutMode: boolean;
+}
+
+export default function EventDetailPrefixInfoForm({
+  floorId,
+  onChangePrefix,
+  prefixData,
+  onAddRange,
+  onChangeRange,
+  onDeletePrefix,
+  onDeleteRange,
+  isPutMode,
+}: EventDetailPrefixInfoFormProps) {
+  return (
+    <div className={cn("container")}>
+      {isPutMode && (
+        <Button
+          className={cn("deletePrefixBtn")}
+          color="red"
+          onClick={() => onDeletePrefix(floorId, prefixData.prefixId)}
+        >
+          <Txt size="h6" color="white">
+            접두사 삭제
+          </Txt>
+        </Button>
+      )}
+      <TextInput
+        label="접두사"
+        value={prefixData.lockerPrefix}
+        id="lockerPrefix"
+        type="text"
+        placeholder="접두사 입력 (예: A), 빈 값 가능"
+        readOnly={!isPutMode}
+        onChange={(e) => {
+          const value = e.target.value;
+          onChangePrefix(floorId, prefixData.prefixId, value);
+        }}
+      />
+      <div className={cn("rangeContainer")}>
+        <div className={cn("rangeTitle")}>
+          <Txt size="small" weight="medium">
+            번호 범위 추가
+          </Txt>
+          {isPutMode && (
+            <Button className={cn("addRangeBtn")} color="blue" onClick={() => onAddRange(floorId, prefixData.prefixId)}>
+              <Txt size="h6" color="white">
+                + 범위 추가
+              </Txt>
+            </Button>
+          )}
+        </div>
+        {prefixData.ranges.map((range) => (
+          <EventDetailRangeInfoForm
+            floorId={floorId}
+            prefixId={prefixData.prefixId}
+            rangeData={range}
+            key={range.rangeId}
+            onChangeRange={onChangeRange}
+            onDeleteRange={onDeleteRange}
+            isPutMode={isPutMode}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/page/committee/event-detail/RangeInfoForm/index.module.scss
+++ b/src/components/page/committee/event-detail/RangeInfoForm/index.module.scss
@@ -1,0 +1,11 @@
+.container {
+  background-color: white;
+  border-radius: 1rem;
+  @include flexSort(row, null, flex-end, 1rem);
+  padding: 2rem;
+}
+
+.deleteRangeBtn {
+  width: 12rem;
+  height: 5rem;
+}

--- a/src/components/page/committee/event-detail/RangeInfoForm/index.tsx
+++ b/src/components/page/committee/event-detail/RangeInfoForm/index.tsx
@@ -1,0 +1,77 @@
+import Txt from "@/components/design-system/Txt";
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import TextInput from "@/components/common/TextInput";
+import "react-datepicker/dist/react-datepicker.css";
+import { EventDetailForm } from "@/types/committee/event";
+import Button from "@/components/design-system/Button";
+
+const cn = classNames.bind(styles);
+
+interface EventDetailRangeInfoFormProps {
+  floorId: number;
+  prefixId: number | string;
+  rangeData: EventDetailForm["floors"][number]["prefixes"][number]["ranges"][number];
+  onChangeRange: (
+    floorId: number,
+    prefixId: number | string,
+    rangeId: number,
+    type: "start" | "end",
+    lockerNumber: number | null,
+  ) => void;
+  onDeleteRange: (floorId: number, prefixId: number | string, rangeId: number) => void;
+  isPutMode: boolean;
+}
+
+export default function EventDetailRangeInfoForm({
+  floorId,
+  prefixId,
+  rangeData,
+  onChangeRange,
+  onDeleteRange,
+  isPutMode,
+}: EventDetailRangeInfoFormProps) {
+  return (
+    <div className={cn("container")}>
+      <TextInput
+        label="시작 번호"
+        value={rangeData.lockerStartNumber ?? 0}
+        id="startLockerNumber"
+        type="text"
+        readOnly={!isPutMode}
+        onChange={(e) => {
+          const value = e.target.value;
+          const numberValue = Number(value);
+          if (!isNaN(numberValue)) {
+            onChangeRange(floorId, prefixId, rangeData.rangeId, "start", numberValue);
+          }
+        }}
+      />
+      <TextInput
+        label="종료 번호"
+        value={rangeData.lockerEndNumber ?? 0}
+        id="endLockerNumber"
+        type="text"
+        readOnly={!isPutMode}
+        onChange={(e) => {
+          const value = e.target.value;
+          const numberValue = Number(value);
+          if (!isNaN(numberValue)) {
+            onChangeRange(floorId, prefixId, rangeData.rangeId, "end", numberValue);
+          }
+        }}
+      />
+      {isPutMode && (
+        <Button
+          className={cn("deleteRangeBtn")}
+          color="red"
+          onClick={() => onDeleteRange(floorId, prefixId, rangeData.rangeId)}
+        >
+          <Txt size="h6" color="white">
+            삭제
+          </Txt>
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/page/committee/event-detail/index.module.scss
+++ b/src/components/page/committee/event-detail/index.module.scss
@@ -1,0 +1,4 @@
+.container {
+  padding: 4rem;
+  @include flexSort(column, null, null, 3rem);
+}

--- a/src/components/page/committee/event-detail/index.tsx
+++ b/src/components/page/committee/event-detail/index.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import Txt from "@/components/design-system/Txt";
+import { useEventDetailForm } from "@/hooks/committee/event/useEventDetailForm";
+import EventDetailInfoForm from "@/components/page/committee/event-detail/InfoForm";
+import EventDetailLockerInfoForm from "@/components/page/committee/event-detail/LockerInfoForm";
+
+const cn = classNames.bind(styles);
+
+export default function EventDetail() {
+  const {
+    formData,
+    setFormData,
+    onAddFloor,
+    onChangeFloorNumber,
+    onAddPrefix,
+    onChangePrefix,
+    onAddRange,
+    onChangeRange,
+    onDeleteFloor,
+    onDeletePrefix,
+    onDeleteRange,
+    organizations,
+    departments,
+    onDeleteDepartment,
+    onSelectDepartment,
+    onSelectOrganizations,
+    onPutEvent,
+    isPutMode,
+    onPutClick,
+  } = useEventDetailForm();
+
+  return (
+    <div className={cn("container")}>
+      <Txt color="primary" size="h3" weight="medium">
+        이벤트
+      </Txt>
+      <EventDetailInfoForm
+        formData={formData}
+        setFormData={setFormData}
+        organizations={organizations}
+        departments={departments}
+        onDeleteDepartment={onDeleteDepartment}
+        onSelectDepartment={onSelectDepartment}
+        onSelectOrganizations={onSelectOrganizations}
+        isPutMode={isPutMode}
+      />
+      <Txt size="h4" weight="medium">
+        사물함 정보
+      </Txt>
+      <EventDetailLockerInfoForm
+        formData={formData}
+        onAddFloor={onAddFloor}
+        onChangeFloorNumber={onChangeFloorNumber}
+        onAddPrefix={onAddPrefix}
+        onChangePrefix={onChangePrefix}
+        onAddRange={onAddRange}
+        onChangeRange={onChangeRange}
+        onDeleteFloor={onDeleteFloor}
+        onDeletePrefix={onDeletePrefix}
+        onDeleteRange={onDeleteRange}
+        onPutEvent={onPutEvent}
+        isPutMode={isPutMode}
+        onPutClick={onPutClick}
+      />
+    </div>
+  );
+}

--- a/src/components/page/committee/event-list/index.tsx
+++ b/src/components/page/committee/event-list/index.tsx
@@ -24,6 +24,7 @@ export default function EventList() {
     onDeleteEvent,
     onChangeEventPublish,
     isLoading,
+    onEventClick,
   } = useEventList();
 
   return (
@@ -82,7 +83,7 @@ export default function EventList() {
             </tr>
           ) : (
             eventList.map((event) => (
-              <tr key={event.id} className={cn("tr")}>
+              <tr key={event.id} className={cn("tr")} onClick={() => onEventClick(event.id)}>
                 <td className={cn("tableData")}>
                   <Txt size="h6">{event.title}</Txt>
                 </td>

--- a/src/constants/routes/index.ts
+++ b/src/constants/routes/index.ts
@@ -20,5 +20,6 @@ export const ROUTE = {
     CREATE_EVENT: "/committee/create-event",
     CREATE_ANNOUNCEMENT: "/committee/create-announcement",
     APPROVE_WAIT: "/committee/approve-wait",
+    EVENT: "/committee/event",
   },
 };

--- a/src/functions/convertPutEventForm.ts
+++ b/src/functions/convertPutEventForm.ts
@@ -1,0 +1,26 @@
+import { convertToKST } from "@/functions/date";
+import { EventDetailForm } from "@/types/committee/event";
+
+export const convertPutEventForm = (formData: EventDetailForm) => {
+  const startAtKST = convertToKST(formData.startAt as Date);
+  const endAtKST = convertToKST(formData.endAt as Date);
+
+  const eventData = {
+    title: formData.title,
+    startAt: startAtKST,
+    endAt: endAtKST,
+    participationDepartmentIds: formData.participationDepartmentIds.map((department) => department.id),
+    floors: formData.floors.map((floor) => ({
+      floorNumber: floor.floorNumber as number,
+      prefixes: floor.prefixes.map((prefix) => ({
+        lockerPrefix: prefix.lockerPrefix,
+        ranges: prefix.ranges.map((range) => ({
+          lockerStartNumber: range.lockerStartNumber as number,
+          lockerEndNumber: range.lockerEndNumber as number,
+        })),
+      })),
+    })),
+  };
+
+  return { eventData };
+};

--- a/src/functions/date.ts
+++ b/src/functions/date.ts
@@ -1,3 +1,33 @@
 export const convertToKST = (dateString: Date): string => {
   return new Date(new Date(dateString).getTime() + 9 * 60 * 60 * 1000).toISOString().split(".")[0];
 };
+
+export const getYear = (dateString: Date | string): string => {
+  const date = typeof dateString === "string" ? new Date(dateString) : dateString;
+
+  return date.getFullYear().toString();
+};
+
+export const getMonth = (dateString: Date | string): string => {
+  const date = typeof dateString === "string" ? new Date(dateString) : dateString;
+
+  return (date.getMonth() + 1).toString().padStart(2, "0");
+};
+
+export const getDate = (dateString: Date | string): string => {
+  const date = typeof dateString === "string" ? new Date(dateString) : dateString;
+
+  return date.getDate().toString().padStart(2, "0");
+};
+
+export const getHours = (dateString: Date | string): string => {
+  const date = typeof dateString === "string" ? new Date(dateString) : dateString;
+
+  return date.getHours().toString().padStart(2, "0");
+};
+
+export const getMinutes = (dateString: Date | string): string => {
+  const date = typeof dateString === "string" ? new Date(dateString) : dateString;
+
+  return date.getMinutes().toString().padStart(2, "0");
+};

--- a/src/functions/validator/putEventValidator.ts
+++ b/src/functions/validator/putEventValidator.ts
@@ -1,0 +1,44 @@
+import { CREATE_EVENT_VALIDATION } from "@/constants/validation/createEvent";
+import { EventDetailForm } from "@/types/committee/event";
+
+export const putEventValidator = (formData: EventDetailForm) => {
+  if (!formData.title) {
+    alert(CREATE_EVENT_VALIDATION.title.required);
+    return false;
+  }
+
+  if (!formData.startAt) {
+    alert(CREATE_EVENT_VALIDATION.startAt.required);
+    return false;
+  }
+
+  if (!formData.endAt) {
+    alert(CREATE_EVENT_VALIDATION.endAt.required);
+    return false;
+  }
+
+  if (formData.participationDepartmentIds.length === 0) {
+    alert(CREATE_EVENT_VALIDATION.department.required);
+    return false;
+  }
+
+  const invalidFloorNumber = formData.floors.find((floor) => floor.floorNumber === null || floor.floorNumber < 1);
+
+  if (invalidFloorNumber) {
+    alert(CREATE_EVENT_VALIDATION.floor.min);
+    return false;
+  }
+
+  const invalidLockerNumber = formData.floors.find((floor) =>
+    floor.prefixes.some((prefix) =>
+      prefix.ranges.some((range) => range.lockerStartNumber === null || range.lockerEndNumber === null),
+    ),
+  );
+
+  if (invalidLockerNumber) {
+    alert(CREATE_EVENT_VALIDATION.lockerNumber.required);
+    return false;
+  }
+
+  return true;
+};

--- a/src/hooks/committee/event/useEventDetailForm.ts
+++ b/src/hooks/committee/event/useEventDetailForm.ts
@@ -241,7 +241,7 @@ export const useEventDetailForm = () => {
     }));
   };
 
-  const onAddRange = (floorId: number, prefixId: number) => {
+  const onAddRange = (floorId: number, prefixId: number | string) => {
     const newRange = {
       rangeId: Date.now(),
       lockerStartNumber: null,
@@ -270,7 +270,7 @@ export const useEventDetailForm = () => {
 
   const onChangeRange = (
     floorId: number,
-    prefixId: number,
+    prefixId: number | string,
     rangeId: number | string,
     type: "start" | "end",
     lockerNumber: number | null,

--- a/src/hooks/committee/event/useEventDetailForm.ts
+++ b/src/hooks/committee/event/useEventDetailForm.ts
@@ -1,0 +1,368 @@
+import { CREATE_EVENT_VALIDATION } from "@/constants/validation/createEvent";
+import { useDepartmentsQuery, useOrganizationsQuery } from "@/hooks/tanstack-query/common/sign-up";
+import { CreateEventForm, EventDetailForm } from "@/types/committee/event";
+import { ChangeEvent, useEffect, useState } from "react";
+import { useGetEventId } from "@/hooks/common/useGetEventId";
+import { useGetEvent } from "@/hooks/tanstack-query/committee/event/useGetEvent";
+import { ApiResponseError } from "@/types/common/api";
+import { useCommitteeCertification } from "../sign-in/useCommitteeCertification";
+import { usePutEvent } from "@/hooks/tanstack-query/committee/event/usePutEvent";
+import { putEventValidator } from "@/functions/validator/putEventValidator";
+import { convertPutEventForm } from "@/functions/convertPutEventForm";
+
+export const useEventDetailForm = () => {
+  const { eventId } = useGetEventId();
+
+  const { data, isError, error } = useGetEvent(eventId);
+
+  useCommitteeCertification(isError, error as ApiResponseError);
+
+  const [isPutMode, setIsPutMode] = useState(false);
+
+  const { onPutEvent: putEvent } = usePutEvent(eventId);
+
+  const [formData, setFormData] = useState<EventDetailForm>({
+    title: "",
+    startAt: null,
+    endAt: null,
+    affiliation: {
+      id: 0,
+      value: "값을 선택해주세요.",
+    },
+    participationDepartmentIds: [],
+    floors: [
+      {
+        floorNumber: null,
+        floorId: Date.now(),
+        prefixes: [
+          {
+            prefixId: Date.now(),
+            lockerPrefix: "",
+            ranges: [
+              {
+                rangeId: Date.now(),
+                lockerStartNumber: null,
+                lockerEndNumber: null,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+
+  let { data: organizations } = useOrganizationsQuery("학생회");
+
+  if (!organizations) {
+    organizations = [{ id: 0, value: "값을 선택해주세요." }];
+  } else {
+    organizations = [{ id: 0, value: "값을 선택해주세요." }, ...organizations];
+  }
+
+  let departments = useDepartmentsQuery(formData.affiliation.id);
+
+  if (!departments) {
+    departments = [{ id: 0, value: "값을 선택해주세요." }];
+  }
+
+  useEffect(() => {
+    if (data) {
+      setFormData({
+        title: data.title,
+        startAt: data.startAt,
+        endAt: data.endAt,
+        affiliation: {
+          id: 0,
+          value: "값을 선택해주세요.",
+        },
+        participationDepartmentIds: data.participationDepartmentIds,
+        floors: data.floors,
+      });
+    }
+  }, [data]);
+
+  const onSelectOrganizations = (e: ChangeEvent<HTMLSelectElement>) => {
+    const { value } = e.target;
+    const selectedId = Number(e.target.options[e.target.selectedIndex].getAttribute("data-id"));
+
+    setFormData((prev) => ({
+      ...prev,
+      affiliation: {
+        id: selectedId,
+        value: value,
+      },
+    }));
+  };
+
+  const onSelectDepartment = (e: ChangeEvent<HTMLSelectElement>) => {
+    const { value } = e.target;
+    const selectedId = Number(e.target.options[e.target.selectedIndex].getAttribute("data-id"));
+
+    const isDuplicate = formData.participationDepartmentIds.some((department) => department.id === selectedId);
+
+    if (isDuplicate) {
+      alert(CREATE_EVENT_VALIDATION.department.duplicate);
+      return;
+    }
+
+    setFormData((prev) => ({
+      ...prev,
+      participationDepartmentIds: [
+        ...prev.participationDepartmentIds,
+        {
+          id: selectedId,
+          value: value,
+        },
+      ],
+    }));
+  };
+
+  const onDeleteDepartment = (id: number) => {
+    setFormData((prev) => ({
+      ...prev,
+      participationDepartmentIds: prev.participationDepartmentIds.filter((department) => department.id !== id),
+    }));
+  };
+
+  const onAddFloor = () => {
+    const newFloor: CreateEventForm["floors"][number] = {
+      floorNumber: null,
+      floorId: Date.now(),
+      prefixes: [
+        {
+          prefixId: Date.now(),
+          lockerPrefix: "",
+          ranges: [
+            {
+              rangeId: Date.now(),
+              lockerStartNumber: null,
+              lockerEndNumber: null,
+            },
+          ],
+        },
+      ],
+    };
+    setFormData((prev) => ({
+      ...prev,
+      floors: [...prev.floors, newFloor],
+    }));
+  };
+
+  const onChangeFloorNumber = (floorId: number, floorNumber: number) => {
+    setFormData((prev) => ({
+      ...prev,
+      floors: prev.floors.map((floor) =>
+        floor.floorId === floorId
+          ? {
+              ...floor,
+              floorNumber,
+            }
+          : floor,
+      ),
+    }));
+  };
+
+  const onDeleteFloor = (floorId: number) => {
+    if (formData.floors.length === 1) {
+      alert(CREATE_EVENT_VALIDATION.floor.required);
+      return;
+    }
+
+    setFormData((prev) => ({
+      ...prev,
+      floors: prev.floors.filter((floor) => floor.floorId !== floorId),
+    }));
+  };
+
+  const onAddPrefix = (floorId: number) => {
+    const newPrefix: CreateEventForm["floors"][number]["prefixes"][number] = {
+      prefixId: Date.now(),
+      lockerPrefix: "",
+      ranges: [
+        {
+          rangeId: Date.now(),
+          lockerStartNumber: null,
+          lockerEndNumber: null,
+        },
+      ],
+    };
+
+    setFormData((prev) => ({
+      ...prev,
+      floors: prev.floors.map((floor) =>
+        floor.floorId === floorId
+          ? {
+              ...floor,
+              prefixes: [...floor.prefixes, newPrefix],
+            }
+          : floor,
+      ),
+    }));
+  };
+
+  const onChangePrefix = (floorId: number, prefixId: number | string, lockerPrefix: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      floors: prev.floors.map((floor) =>
+        floor.floorId === floorId
+          ? {
+              ...floor,
+              prefixes: floor.prefixes.map((prefix) =>
+                prefix.prefixId === prefixId
+                  ? {
+                      ...prefix,
+                      lockerPrefix,
+                    }
+                  : prefix,
+              ),
+            }
+          : floor,
+      ),
+    }));
+  };
+
+  const onDeletePrefix = (floorId: number, prefixId: number | string) => {
+    const targetFloor = formData.floors.find((floor) => floor.floorId === floorId);
+    if (targetFloor?.prefixes.length === 1) {
+      alert(CREATE_EVENT_VALIDATION.prefix.required);
+      return;
+    }
+
+    setFormData((prev) => ({
+      ...prev,
+      floors: prev.floors.map((floor) =>
+        floor.floorId === floorId
+          ? {
+              ...floor,
+              prefixes: floor.prefixes.filter((prefix) => prefix.prefixId !== prefixId),
+            }
+          : floor,
+      ),
+    }));
+  };
+
+  const onAddRange = (floorId: number, prefixId: number) => {
+    const newRange = {
+      rangeId: Date.now(),
+      lockerStartNumber: null,
+      lockerEndNumber: null,
+    };
+
+    setFormData((prev) => ({
+      ...prev,
+      floors: prev.floors.map((floor) =>
+        floor.floorId === floorId
+          ? {
+              ...floor,
+              prefixes: floor.prefixes.map((prefix) =>
+                prefix.prefixId === prefixId
+                  ? {
+                      ...prefix,
+                      ranges: [...prefix.ranges, newRange],
+                    }
+                  : prefix,
+              ),
+            }
+          : floor,
+      ),
+    }));
+  };
+
+  const onChangeRange = (
+    floorId: number,
+    prefixId: number,
+    rangeId: number | string,
+    type: "start" | "end",
+    lockerNumber: number | null,
+  ) => {
+    setFormData((prev) => ({
+      ...prev,
+      floors: prev.floors.map((floor) =>
+        floor.floorId === floorId
+          ? {
+              ...floor,
+              prefixes: floor.prefixes.map((prefix) =>
+                prefix.prefixId === prefixId
+                  ? {
+                      ...prefix,
+                      ranges: prefix.ranges.map((range) =>
+                        range.rangeId === rangeId
+                          ? type === "start"
+                            ? { ...range, lockerStartNumber: lockerNumber }
+                            : { ...range, lockerEndNumber: lockerNumber }
+                          : range,
+                      ),
+                    }
+                  : prefix,
+              ),
+            }
+          : floor,
+      ),
+    }));
+  };
+
+  const onDeleteRange = (floorId: number, prefixId: number | string, rangeId: number) => {
+    const targetFloor = formData.floors.find((floor) => floor.floorId === floorId);
+    const targetPrefix = targetFloor?.prefixes.find((prefix) => prefix.prefixId === prefixId);
+
+    if (targetPrefix && targetPrefix.ranges.length === 1) {
+      alert(CREATE_EVENT_VALIDATION.range.required);
+      return;
+    }
+
+    setFormData((prev) => ({
+      ...prev,
+      floors: prev.floors.map((floor) =>
+        floor.floorId === floorId
+          ? {
+              ...floor,
+              prefixes: floor.prefixes.map((prefix) =>
+                prefix.prefixId === prefixId
+                  ? {
+                      ...prefix,
+                      ranges: prefix.ranges.filter((range) => range.rangeId !== rangeId),
+                    }
+                  : prefix,
+              ),
+            }
+          : floor,
+      ),
+    }));
+  };
+
+  const onPutEvent = () => {
+    if (!putEventValidator(formData)) {
+      return;
+    }
+
+    const { eventData } = convertPutEventForm(formData);
+
+    putEvent(eventData);
+  };
+
+  const onPutClick = () => {
+    setIsPutMode((prev) => !prev);
+  };
+
+  return {
+    formData,
+    setFormData,
+    onAddFloor,
+    onChangeFloorNumber,
+    onAddPrefix,
+    onChangePrefix,
+    onAddRange,
+    onChangeRange,
+    onDeleteFloor,
+    onDeletePrefix,
+    onDeleteRange,
+    onPutEvent,
+    organizations,
+    departments,
+    onSelectDepartment,
+    onDeleteDepartment,
+    onSelectOrganizations,
+    isPutMode,
+    onPutClick,
+  };
+};

--- a/src/hooks/committee/event/useEventList.ts
+++ b/src/hooks/committee/event/useEventList.ts
@@ -5,9 +5,12 @@ import { useDeleteEvent } from "@/hooks/tanstack-query/committee/event/useDelete
 import { usePutEventPublish } from "@/hooks/tanstack-query/committee/event/usePutEventPublish";
 import { useCommitteeCertification } from "../sign-in/useCommitteeCertification";
 import { ApiResponseError } from "@/types/common/api";
+import { useRouter } from "next/navigation";
+import { ROUTE } from "@/constants/routes";
 
 export const useEventList = () => {
   const { page: currentPage } = useGetPageParams();
+  const router = useRouter();
   const { pagesPerGroup, queryParams, setPage } = useEventPagination(currentPage);
 
   const { data, isLoading, isError, error } = useGetEventListQuery(queryParams);
@@ -20,6 +23,10 @@ export const useEventList = () => {
   const eventList = data?.content || [];
   const totalElements = data?.totalElements || 0;
 
+  const onEventClick = (eventId: string) => {
+    router.push(`${ROUTE.COMMITTEE.EVENT}/${eventId}`);
+  };
+
   return {
     eventList,
     totalElements,
@@ -30,5 +37,6 @@ export const useEventList = () => {
     onDeleteEvent,
     onChangeEventPublish,
     isLoading,
+    onEventClick,
   };
 };

--- a/src/hooks/common/useGetEventId.ts
+++ b/src/hooks/common/useGetEventId.ts
@@ -1,0 +1,10 @@
+import { usePathname } from "next/navigation";
+
+export const useGetEventId = () => {
+  const pathName = usePathname();
+  const eventId = pathName.split("/").at(-1) || "";
+
+  return {
+    eventId,
+  };
+};

--- a/src/hooks/tanstack-query/committee/event/useGetEvent.ts
+++ b/src/hooks/tanstack-query/committee/event/useGetEvent.ts
@@ -1,0 +1,12 @@
+import { getEvent } from "@/apis/committee/event";
+import { EventDetail } from "@/apis/dtos/committee/event";
+import { ApiResponseError } from "@/types/common/api";
+import { useQuery } from "@tanstack/react-query";
+
+export const useGetEvent = (eventId: string) => {
+  return useQuery<EventDetail, ApiResponseError>({
+    queryKey: ["event", eventId],
+    queryFn: () => getEvent(eventId),
+    enabled: !!eventId,
+  });
+};

--- a/src/hooks/tanstack-query/committee/event/usePutEvent.ts
+++ b/src/hooks/tanstack-query/committee/event/usePutEvent.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { putEvent } from "@/apis/committee/event";
+import { PutEventRequest } from "@/types/committee/event";
+import { ApiResponseError } from "@/types/common/api";
+
+export const usePutEvent = (eventId: string) => {
+  const { mutate } = usePutEventMutate();
+  const queryClient = useQueryClient();
+
+  const onPutEvent = (formData: PutEventRequest) => {
+    mutate(
+      { formData, eventId },
+      {
+        onError: (error) => {
+          alert(error.response.data.message || "이벤트 수정에 실패하였습니다.");
+        },
+        onSuccess: () => {
+          alert("이벤트 수정에 성공하셨습니다.");
+          queryClient.invalidateQueries({ queryKey: ["event", eventId] });
+        },
+      },
+    );
+  };
+  return {
+    onPutEvent,
+  };
+};
+
+export const usePutEventMutate = () => {
+  return useMutation<void, ApiResponseError, { formData: PutEventRequest; eventId: string }>({
+    mutationKey: ["putEvent"],
+    mutationFn: putEvent,
+  });
+};

--- a/src/types/committee/event/index.ts
+++ b/src/types/committee/event/index.ts
@@ -41,3 +41,47 @@ export interface CreateEventRequest {
     }[];
   }[];
 }
+
+export interface PutEventRequest {
+  title: string;
+  startAt: string;
+  endAt: string;
+  participationDepartmentIds: number[];
+  floors: {
+    floorNumber: number;
+    prefixes: {
+      lockerPrefix: string;
+      ranges: {
+        lockerStartNumber: number;
+        lockerEndNumber: number;
+      }[];
+    }[];
+  }[];
+}
+
+export interface EventDetailForm {
+  title: string;
+  startAt: Date | null | string;
+  endAt: Date | null | string;
+  affiliation: {
+    id: number;
+    value: string;
+  };
+  participationDepartmentIds: {
+    id: number;
+    value: string;
+  }[];
+  floors: {
+    floorNumber: null | number;
+    floorId: number;
+    prefixes: {
+      prefixId: number | string;
+      lockerPrefix: string;
+      ranges: {
+        rangeId: number;
+        lockerStartNumber: null | number;
+        lockerEndNumber: null | number;
+      }[];
+    }[];
+  }[];
+}


### PR DESCRIPTION
### 개요

close #94 

### 작업사항

- 이벤트 상세 페이지 구현

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 이벤트 상세 페이지 및 편집 기능이 추가되었습니다.
  - 이벤트의 층, 프리픽스, 사물함 번호 범위 등 상세 정보를 확인하고 수정할 수 있습니다.
  - 이벤트 목록에서 이벤트 클릭 시 상세 페이지로 이동할 수 있습니다.

- **UI/스타일**
  - 이벤트 상세 및 편집 폼, 사물함 정보, 층/프리픽스/범위 관리 UI 컴포넌트와 스타일이 추가되었습니다.
  - 날짜 및 시간 선택기를 포함한 폼 입력 UI가 개선되었습니다.

- **버그 수정 및 개선**
  - 이벤트 편집 시 유효성 검사 및 입력값 검증 기능이 추가되었습니다.
  - 날짜/시간, 부서 선택 등 입력값의 형식과 범위를 확인합니다.

- **기타**
  - 이벤트 상세 조회 및 수정 관련 API 연동이 추가되었습니다.
  - 라우트 및 네비게이션 기능이 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->