### PR TITLE
refactor: 이벤트 수정 시 진행중이거나 종료된 이벤트에 대해 수정이 불가능하다는 alert가 나온 후 수정 상태를 불가능으로 변경

### DIFF
--- a/src/hooks/committee/event/useEventDetailForm.ts
+++ b/src/hooks/committee/event/useEventDetailForm.ts
@@ -19,7 +19,7 @@ export const useEventDetailForm = () => {
 
   const [isPutMode, setIsPutMode] = useState(false);
 
-  const { onPutEvent: putEvent } = usePutEvent(eventId);
+  const { onPutEvent: putEvent } = usePutEvent(eventId, setIsPutMode);
 
   const [formData, setFormData] = useState<EventDetailForm>({
     title: "",

--- a/src/hooks/tanstack-query/committee/event/usePutEvent.ts
+++ b/src/hooks/tanstack-query/committee/event/usePutEvent.ts
@@ -2,8 +2,9 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { putEvent } from "@/apis/committee/event";
 import { PutEventRequest } from "@/types/committee/event";
 import { ApiResponseError } from "@/types/common/api";
+import { Dispatch, SetStateAction } from "react";
 
-export const usePutEvent = (eventId: string) => {
+export const usePutEvent = (eventId: string, setIsPutMode: Dispatch<SetStateAction<boolean>>) => {
   const { mutate } = usePutEventMutate();
   const queryClient = useQueryClient();
 
@@ -12,6 +13,9 @@ export const usePutEvent = (eventId: string) => {
       { formData, eventId },
       {
         onError: (error) => {
+          if (error.response.data.code === "E009") {
+            setIsPutMode((prev) => !prev);
+          }
           alert(error.response.data.message || "이벤트 수정에 실패하였습니다.");
         },
         onSuccess: () => {

--- a/src/hooks/tanstack-query/committee/event/usePutEvent.ts
+++ b/src/hooks/tanstack-query/committee/event/usePutEvent.ts
@@ -14,7 +14,7 @@ export const usePutEvent = (eventId: string, setIsPutMode: Dispatch<SetStateActi
       {
         onError: (error) => {
           if (error.response.data.code === "E009") {
-            setIsPutMode((prev) => !prev);
+            setIsPutMode(false);
           }
           alert(error.response.data.message || "이벤트 수정에 실패하였습니다.");
         },

--- a/src/types/common/api/index.ts
+++ b/src/types/common/api/index.ts
@@ -3,6 +3,7 @@ export interface ApiResponseError {
     status: number;
     data: {
       message: string;
+      code: string;
     };
   };
 }


### PR DESCRIPTION
### 개요

close #109 

### 작업사항

- 이벤트 수정 시 진행중이거나 종료된 이벤트에 대해 수정이 불가능하다는 alert가 나온 후 수정 상태를 불가능으로 변경

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
	- 이벤트 수정 중 특정 오류 코드(E009) 발생 시, 편집 모드가 자동으로 해제되어 더 명확하게 동작합니다.  
- **기타**
	- 오류 응답에 코드 정보가 추가되어, 향후 더 정확한 안내가 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->