### PR TITLE
refactor: 이벤트 상세 페이지 수정

### DIFF
--- a/src/components/page/committee/event-detail/FloorInfoForm/index.tsx
+++ b/src/components/page/committee/event-detail/FloorInfoForm/index.tsx
@@ -57,7 +57,7 @@ export default function EventDetailFloorInfoForm({
       <TextInput
         label="층수"
         value={floorData.floorNumber ?? 0}
-        id="floorNumber"
+        id={`floorNumber-${floorData.floorId}`}
         type="text"
         readOnly={!isPutMode}
         placeholder="숫자로 입력해주세요. (예: 2)"

--- a/src/components/page/committee/event-detail/PrefixInfoForm/index.tsx
+++ b/src/components/page/committee/event-detail/PrefixInfoForm/index.tsx
@@ -52,7 +52,7 @@ export default function EventDetailPrefixInfoForm({
       <TextInput
         label="접두사"
         value={prefixData.lockerPrefix}
-        id="lockerPrefix"
+        id={`lockerPrefix-${prefixData.prefixId}`}
         type="text"
         placeholder="접두사 입력 (예: A), 빈 값 가능"
         readOnly={!isPutMode}

--- a/src/components/page/committee/event-detail/RangeInfoForm/index.tsx
+++ b/src/components/page/committee/event-detail/RangeInfoForm/index.tsx
@@ -36,7 +36,7 @@ export default function EventDetailRangeInfoForm({
       <TextInput
         label="시작 번호"
         value={rangeData.lockerStartNumber ?? 0}
-        id="startLockerNumber"
+        id={`startLockerNumber-${rangeData.rangeId}`}
         type="text"
         readOnly={!isPutMode}
         onChange={(e) => {
@@ -50,7 +50,7 @@ export default function EventDetailRangeInfoForm({
       <TextInput
         label="종료 번호"
         value={rangeData.lockerEndNumber ?? 0}
-        id="endLockerNumber"
+        id={`endLockerNumber-${rangeData.rangeId}`}
         type="text"
         readOnly={!isPutMode}
         onChange={(e) => {

--- a/src/functions/validator/putEventValidator.ts
+++ b/src/functions/validator/putEventValidator.ts
@@ -3,30 +3,25 @@ import { EventDetailForm } from "@/types/committee/event";
 
 export const putEventValidator = (formData: EventDetailForm) => {
   if (!formData.title) {
-    alert(CREATE_EVENT_VALIDATION.title.required);
-    return false;
+    return CREATE_EVENT_VALIDATION.title.required;
   }
 
   if (!formData.startAt) {
-    alert(CREATE_EVENT_VALIDATION.startAt.required);
-    return false;
+    return CREATE_EVENT_VALIDATION.startAt.required;
   }
 
   if (!formData.endAt) {
-    alert(CREATE_EVENT_VALIDATION.endAt.required);
-    return false;
+    return CREATE_EVENT_VALIDATION.endAt.required;
   }
 
   if (formData.participationDepartmentIds.length === 0) {
-    alert(CREATE_EVENT_VALIDATION.department.required);
-    return false;
+    return CREATE_EVENT_VALIDATION.department.required;
   }
 
   const invalidFloorNumber = formData.floors.find((floor) => floor.floorNumber === null || floor.floorNumber < 1);
 
   if (invalidFloorNumber) {
-    alert(CREATE_EVENT_VALIDATION.floor.min);
-    return false;
+    return CREATE_EVENT_VALIDATION.floor.min;
   }
 
   const invalidLockerNumber = formData.floors.find((floor) =>
@@ -36,9 +31,8 @@ export const putEventValidator = (formData: EventDetailForm) => {
   );
 
   if (invalidLockerNumber) {
-    alert(CREATE_EVENT_VALIDATION.lockerNumber.required);
-    return false;
+    return CREATE_EVENT_VALIDATION.lockerNumber.required;
   }
 
-  return true;
+  return false;
 };

--- a/src/functions/validator/putEventValidator.ts
+++ b/src/functions/validator/putEventValidator.ts
@@ -34,5 +34,5 @@ export const putEventValidator = (formData: EventDetailForm) => {
     return CREATE_EVENT_VALIDATION.lockerNumber.required;
   }
 
-  return false;
+  return null;
 };

--- a/src/hooks/committee/event/useEventDetailForm.ts
+++ b/src/hooks/committee/event/useEventDetailForm.ts
@@ -331,7 +331,10 @@ export const useEventDetailForm = () => {
   };
 
   const onPutEvent = () => {
-    if (!putEventValidator(formData)) {
+    const alertMessage = putEventValidator(formData);
+
+    if (alertMessage) {
+      alert(alertMessage);
       return;
     }
 

--- a/src/types/committee/event/index.ts
+++ b/src/types/committee/event/index.ts
@@ -42,22 +42,7 @@ export interface CreateEventRequest {
   }[];
 }
 
-export interface PutEventRequest {
-  title: string;
-  startAt: string;
-  endAt: string;
-  participationDepartmentIds: number[];
-  floors: {
-    floorNumber: number;
-    prefixes: {
-      lockerPrefix: string;
-      ranges: {
-        lockerStartNumber: number;
-        lockerEndNumber: number;
-      }[];
-    }[];
-  }[];
-}
+export type PutEventRequest = CreateEventRequest;
 
 export interface EventDetailForm {
   title: string;


### PR DESCRIPTION
### 개요

close #111 

### 변경로직

- 이벤트 수정 페이지 input의 id 값 고유하게 변경
- putEventValidator의 리턴값을 alert 메시지로 변경
- PutEventRequest 타입을 CreateEventRequest 타입과 동일하게 변경

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 여러 입력 폼(층 번호, 사물함 접두사, 시작/종료 번호)에서 각 입력 필드의 ID가 고유하게 생성되어, 중복으로 인한 접근성 및 DOM 충돌 문제가 해결되었습니다.

- **리팩터**
  - 이벤트 수정 시 입력값 검증 로직이 개선되어, 유효하지 않은 입력에 대해 명확한 알림 메시지가 표시됩니다.
  - 중복된 타입 정의를 제거하여 코드가 간결해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->