### PR TITLE
refactor: 이벤트 생성 페이지 수정

### DIFF
--- a/src/components/page/committee/CreateEvent/FloorInfoForm/index.tsx
+++ b/src/components/page/committee/CreateEvent/FloorInfoForm/index.tsx
@@ -53,7 +53,7 @@ export default function CreateEventFloorInfoForm({
       <TextInput
         label="층수"
         value={floorData.floorNumber ?? 0}
-        id="floorNumber"
+        id={`floorNumber-${floorData.floorId}`}
         type="text"
         placeholder="숫자로 입력해주세요. (예: 2)"
         onChange={(e) => {

--- a/src/components/page/committee/CreateEvent/PrefixInfoForm/index.tsx
+++ b/src/components/page/committee/CreateEvent/PrefixInfoForm/index.tsx
@@ -48,7 +48,7 @@ export default function CreateEventPrefixInfoForm({
       <TextInput
         label="접두사"
         value={prefixData.lockerPrefix}
-        id="lockerPrefix"
+        id={`lockerPrefix-${prefixData.prefixId}`}
         type="text"
         placeholder="접두사 입력 (예: A), 빈 값 가능"
         onChange={(e) => {

--- a/src/components/page/committee/CreateEvent/RangeInfoForm/index.tsx
+++ b/src/components/page/committee/CreateEvent/RangeInfoForm/index.tsx
@@ -34,7 +34,7 @@ export default function CreateEventRangeInfoForm({
       <TextInput
         label="시작 번호"
         value={rangeData.lockerStartNumber ?? 0}
-        id="startLockerNumber"
+        id={`startLockerNumber-${rangeData.rangeId}`}
         type="text"
         onChange={(e) => {
           const value = e.target.value;
@@ -47,7 +47,7 @@ export default function CreateEventRangeInfoForm({
       <TextInput
         label="종료 번호"
         value={rangeData.lockerEndNumber ?? 0}
-        id="endLockerNumber"
+        id={`endLockerNumber-${rangeData.rangeId}`}
         type="text"
         onChange={(e) => {
           const value = e.target.value;

--- a/src/functions/validator/createEventValidator.ts
+++ b/src/functions/validator/createEventValidator.ts
@@ -3,30 +3,25 @@ import { CreateEventForm } from "@/types/committee/event";
 
 export const createEventValidator = (formData: CreateEventForm) => {
   if (!formData.title) {
-    alert(CREATE_EVENT_VALIDATION.title.required);
-    return false;
+    return CREATE_EVENT_VALIDATION.title.required;
   }
 
   if (!formData.startAt) {
-    alert(CREATE_EVENT_VALIDATION.startAt.required);
-    return false;
+    return CREATE_EVENT_VALIDATION.startAt.required;
   }
 
   if (!formData.endAt) {
-    alert(CREATE_EVENT_VALIDATION.endAt.required);
-    return false;
+    return CREATE_EVENT_VALIDATION.endAt.required;
   }
 
   if (formData.participationDepartmentIds.length === 0) {
-    alert(CREATE_EVENT_VALIDATION.department.required);
-    return false;
+    return CREATE_EVENT_VALIDATION.department.required;
   }
 
   const invalidFloorNumber = formData.floors.find((floor) => floor.floorNumber === null || floor.floorNumber < 1);
 
   if (invalidFloorNumber) {
-    alert(CREATE_EVENT_VALIDATION.floor.min);
-    return false;
+    return CREATE_EVENT_VALIDATION.floor.min;
   }
 
   const invalidLockerNumber = formData.floors.find((floor) =>
@@ -36,9 +31,8 @@ export const createEventValidator = (formData: CreateEventForm) => {
   );
 
   if (invalidLockerNumber) {
-    alert(CREATE_EVENT_VALIDATION.lockerNumber.required);
-    return false;
+    return CREATE_EVENT_VALIDATION.lockerNumber.required;
   }
 
-  return true;
+  return null;
 };

--- a/src/hooks/committee/event/useCreateEventForm.ts
+++ b/src/hooks/committee/event/useCreateEventForm.ts
@@ -19,14 +19,14 @@ export const useCreateEventForm = () => {
     floors: [
       {
         floorNumber: null,
-        floorId: Date.now(),
+        floorId: 1,
         prefixes: [
           {
-            prefixId: Date.now(),
+            prefixId: 1,
             lockerPrefix: "",
             ranges: [
               {
-                rangeId: Date.now(),
+                rangeId: 1,
                 lockerStartNumber: null,
                 lockerEndNumber: null,
               },
@@ -302,7 +302,9 @@ export const useCreateEventForm = () => {
   };
 
   const onCreateEvent = () => {
-    if (!createEventValidator(formData)) {
+    const alertMessage = createEventValidator(formData);
+    if (alertMessage) {
+      alert(alertMessage);
       return;
     }
 


### PR DESCRIPTION
### 개요

close #113 
### 변경로직

- 이벤트 생성 페이지 input의 id를 고유하게 변경
- createEventValidator의 리턴값을 alert 메시지로 변경

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 여러 입력 필드(층 번호, 사물함 접두사, 시작/종료 번호)의 id가 각 항목별로 고유하게 생성되어, 여러 입력 폼이 동시에 렌더링될 때 중복되는 문제가 해결되었습니다.

- **개선 사항**
  - 이벤트 생성 시 유효성 검사에서 오류 발생 시, 구체적인 안내 메시지가 알림으로 표시되어 어떤 항목에 문제가 있는지 쉽게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->