### PR TITLE
feat: 이벤트 신청 페이지에 이벤트 제목과 시간 표시

### DIFF
--- a/src/apis/dtos/student/locker/index.ts
+++ b/src/apis/dtos/student/locker/index.ts
@@ -33,3 +33,31 @@ export class MyRegistrationLocker {
     this.floorNumber = floorNumber;
   }
 }
+
+export class LockerInfo {
+  id: string;
+  title: string;
+  startAt: Date;
+  endAt: Date;
+  status: "READY" | "OPEN" | "CLOSED";
+
+  constructor({
+    id,
+    title,
+    startAt,
+    endAt,
+    status,
+  }: {
+    id: string;
+    title: string;
+    startAt: Date;
+    endAt: Date;
+    status: "READY" | "OPEN" | "CLOSED";
+  }) {
+    this.id = id;
+    this.title = title;
+    this.startAt = startAt;
+    this.endAt = endAt;
+    this.status = status;
+  }
+}

--- a/src/apis/student/apply-locker/index.ts
+++ b/src/apis/student/apply-locker/index.ts
@@ -1,4 +1,4 @@
-import { Locker, LockerList, MyRegistrationLocker } from "@/apis/dtos/student/locker";
+import { Locker, LockerInfo, LockerList, MyRegistrationLocker } from "@/apis/dtos/student/locker";
 import { https } from "@/apis/instance/https";
 
 export const getLockerList = async (eventId: string) => {
@@ -31,4 +31,10 @@ export const postApplyLocker = async ({ eventId, lockerId }: ApplyLockerRequest)
 
 export const deleteMyRegistrationLocker = async (eventId: string) => {
   await https.delete(`events/${eventId}/registrations/me`);
+};
+
+export const getLockerInfo = async (eventId: string) => {
+  const { data } = await https.get(`events/me/${eventId}`);
+
+  return new LockerInfo(data);
 };

--- a/src/components/page/student/ApplyLocker/ApplyInfo/index.module.scss
+++ b/src/components/page/student/ApplyLocker/ApplyInfo/index.module.scss
@@ -1,0 +1,7 @@
+.container {
+  @include flexSort(column, null, null, 1rem);
+}
+
+.skeleton {
+  height: 5rem;
+}

--- a/src/components/page/student/ApplyLocker/ApplyInfo/index.tsx
+++ b/src/components/page/student/ApplyLocker/ApplyInfo/index.tsx
@@ -23,10 +23,10 @@ export default function ApplyInfo() {
   return (
     <div className={cn("container")}>
       <Txt weight="bold" size="h3" className={cn("title")}>
-        제목 : {lockerInfo?.title}
+        제목 : {lockerInfo.title}
       </Txt>
       <Txt weight="bold" size="h3" className={cn("title")}>
-        시간 : {formatToKoreanTime(lockerInfo.startAt)} ~ {formatToKoreanTime(lockerInfo?.endAt)}
+        시간 : {formatToKoreanTime(lockerInfo.startAt)} ~ {formatToKoreanTime(lockerInfo.endAt)}
       </Txt>
     </div>
   );

--- a/src/components/page/student/ApplyLocker/ApplyInfo/index.tsx
+++ b/src/components/page/student/ApplyLocker/ApplyInfo/index.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import classNames from "classnames/bind";
+import styles from "./index.module.scss";
+import Txt from "@/components/design-system/Txt";
+import { useLockerInfo } from "@/hooks/student/apply-locker/useLockerInfo";
+import { formatToKoreanTime } from "@/utils/date";
+import Skeleton from "@/components/common/Skeleton";
+
+const cn = classNames.bind(styles);
+
+export default function ApplyInfo() {
+  const { lockerInfo, isError, isPending } = useLockerInfo();
+
+  if (isPending) {
+    return <Skeleton className={cn("skeleton")} />;
+  }
+
+  if (isError || !lockerInfo) {
+    return null;
+  }
+
+  return (
+    <div className={cn("container")}>
+      <Txt weight="bold" size="h3" className={cn("title")}>
+        제목 : {lockerInfo?.title}
+      </Txt>
+      <Txt weight="bold" size="h3" className={cn("title")}>
+        시간 : {formatToKoreanTime(lockerInfo.startAt)} ~ {formatToKoreanTime(lockerInfo?.endAt)}
+      </Txt>
+    </div>
+  );
+}

--- a/src/components/page/student/ApplyLocker/index.tsx
+++ b/src/components/page/student/ApplyLocker/index.tsx
@@ -7,6 +7,7 @@ import styles from "./index.module.scss";
 import LockerApplicationStatus from "@/components/page/student/ApplyLocker/LockerApplicationStatus/index";
 import ApplyLockerForm from "@/components/page/student/ApplyLocker/Form/index";
 import MyLockerApplicationStatus from "@/components/page/student/ApplyLocker/MyLockerApplicationStatus/index";
+import ApplyInfo from "@/components/page/student/ApplyLocker/ApplyInfo";
 
 const cn = classNames.bind(styles);
 
@@ -14,6 +15,7 @@ export default function ApplyLocker() {
   return (
     <div className={cn("container")}>
       <AffiliationContainer />
+      <ApplyInfo />
       <div className={cn("contentContainer")}>
         <LockerApplicationStatus />
         <div className={cn("formApplicationStatusContainer")}>

--- a/src/hooks/student/apply-locker/useLockerInfo.ts
+++ b/src/hooks/student/apply-locker/useLockerInfo.ts
@@ -1,0 +1,14 @@
+import { useGetApplyLockerPageEventId } from "@/hooks/student/apply-locker/useGetApplyLockerPageEventId";
+import { useGetLockerInfo } from "@/hooks/tanstack-query/student/apply-locker/useGetLockerInfo";
+
+export const useLockerInfo = () => {
+  const { eventId } = useGetApplyLockerPageEventId();
+
+  const { data: lockerInfo, isPending, isError } = useGetLockerInfo(eventId);
+
+  return {
+    lockerInfo,
+    isError,
+    isPending,
+  };
+};

--- a/src/hooks/tanstack-query/student/apply-locker/useGetLockerInfo.ts
+++ b/src/hooks/tanstack-query/student/apply-locker/useGetLockerInfo.ts
@@ -1,0 +1,10 @@
+import { getLockerInfo } from "@/apis/student/apply-locker";
+import { useQuery } from "@tanstack/react-query";
+
+export const useGetLockerInfo = (eventId: string) => {
+  return useQuery({
+    queryKey: ["lockerInfo", eventId],
+    queryFn: () => getLockerInfo(eventId),
+    enabled: !!eventId,
+  });
+};


### PR DESCRIPTION
### 개요

close #105 

### 작업사항

- 이벤트 신청 페이지에 이벤트 제목과 시간 표시

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 사물함 정보(제목, 시작/종료 시간, 상태)를 표시하는 ApplyInfo 컴포넌트가 추가되었습니다.
    - ApplyLocker 페이지에 사물함 정보가 상단에 노출됩니다.
    - 사물함 정보는 로딩 중 스켈레톤 UI를, 오류 시에는 표시되지 않습니다.
    - 사물함 정보를 가져오는 새로운 API 및 커스텀 훅이 도입되었습니다.

- **Style**
    - 사물함 정보 영역에 대한 새로운 스타일이 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->