### PR TITLE
refactor: 로그인 방식 변경

### DIFF
--- a/src/apis/common/sign-in/index.ts
+++ b/src/apis/common/sign-in/index.ts
@@ -1,6 +1,9 @@
+import { LoginInfo } from "@/apis/dtos/common/my-info";
 import { https } from "@/apis/instance/https";
 import { SignInFormData } from "@/types/common/sign-in";
 
 export const postSignIn = async (formData: SignInFormData) => {
-  await https.post("auth/login", formData);
+  const { data } = await https.post("auth/login", formData);
+
+  return new LoginInfo(data);
 };

--- a/src/apis/common/token/index.ts
+++ b/src/apis/common/token/index.ts
@@ -1,10 +1,11 @@
+import { LoginInfo } from "@/apis/dtos/common/my-info";
 import { baseInstance } from "@/apis/instance/baseInstance";
 
 export const postReissue = async () => {
   try {
-    await baseInstance.post("auth/reissue", {});
+    const { data } = await baseInstance.post("auth/reissue", {});
 
-    return true;
+    return new LoginInfo(data);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (error) {
     return false;

--- a/src/apis/dtos/common/my-info/index.ts
+++ b/src/apis/dtos/common/my-info/index.ts
@@ -33,3 +33,13 @@ export class MyInfo {
     this.role = role;
   }
 }
+
+export class LoginInfo {
+  accessToken: string;
+  refreshToken: string;
+
+  constructor({ accessToken, refreshToken }: { accessToken: string; refreshToken: string }) {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+  }
+}

--- a/src/apis/instance/baseInstance.ts
+++ b/src/apis/instance/baseInstance.ts
@@ -8,7 +8,8 @@ export const baseInstance = axios.create({
 });
 
 baseInstance.interceptors.request.use((config) => {
-  const accessToken = localStorage.getItem("accessToken");
+  const accessToken = typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
+
   if (accessToken) {
     config.headers.Authorization = `Bearer ${accessToken}`;
   }

--- a/src/apis/instance/baseInstance.ts
+++ b/src/apis/instance/baseInstance.ts
@@ -5,5 +5,12 @@ export const baseInstance = axios.create({
   headers: {
     "Content-Type": "application/json",
   },
-  withCredentials: true,
+});
+
+baseInstance.interceptors.request.use((config) => {
+  const accessToken = localStorage.getItem("accessToken");
+  if (accessToken) {
+    config.headers.Authorization = `Bearer ${accessToken}`;
+  }
+  return config;
 });

--- a/src/apis/instance/https.ts
+++ b/src/apis/instance/https.ts
@@ -7,8 +7,20 @@ export const https = axios.create({
   headers: {
     "Content-Type": "application/json",
   },
-  withCredentials: true,
 });
+
+https.interceptors.request.use(
+  (config) => {
+    const accessToken = localStorage.getItem("accessToken");
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);
 
 https.interceptors.response.use(
   (response) => {

--- a/src/apis/instance/https.ts
+++ b/src/apis/instance/https.ts
@@ -10,7 +10,8 @@ export const https = axios.create({
 });
 
 https.interceptors.request.use((config) => {
-  const accessToken = localStorage.getItem("accessToken");
+  const accessToken = typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
+
   if (accessToken) {
     config.headers.Authorization = `Bearer ${accessToken}`;
   }

--- a/src/apis/instance/https.ts
+++ b/src/apis/instance/https.ts
@@ -9,18 +9,13 @@ export const https = axios.create({
   },
 });
 
-https.interceptors.request.use(
-  (config) => {
-    const accessToken = localStorage.getItem("accessToken");
-    if (accessToken) {
-      config.headers.Authorization = `Bearer ${accessToken}`;
-    }
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
-  },
-);
+https.interceptors.request.use((config) => {
+  const accessToken = localStorage.getItem("accessToken");
+  if (accessToken) {
+    config.headers.Authorization = `Bearer ${accessToken}`;
+  }
+  return config;
+});
 
 https.interceptors.response.use(
   (response) => {

--- a/src/hooks/tanstack-query/committee/sign-in/index.ts
+++ b/src/hooks/tanstack-query/committee/sign-in/index.ts
@@ -4,6 +4,7 @@ import { ROUTE } from "@/constants/routes";
 import { SignInFormData } from "@/types/common/sign-in";
 import { postSignIn } from "@/apis/common/sign-in";
 import { ApiResponseError } from "@/types/common/api";
+import { LoginInfo } from "@/apis/dtos/common/my-info";
 
 export const useCommitteeSignIn = () => {
   const router = useRouter();
@@ -15,8 +16,11 @@ export const useCommitteeSignIn = () => {
       onError: (error) => {
         alert(error.response.data.message || "로그인에 실패했습니다.");
       },
-      onSuccess: () => {
+      onSuccess: (data) => {
         queryClient.invalidateQueries({ queryKey: ["myInfo"] });
+        localStorage.setItem("accessToken", data.accessToken);
+        localStorage.setItem("refreshToken", data.refreshToken);
+
         router.push(ROUTE.COMMITTEE.APPLY_LIST);
         alert("로그인에 성공했습니다.");
       },
@@ -28,7 +32,7 @@ export const useCommitteeSignIn = () => {
 };
 
 export const useCommitteeSignInMutate = () => {
-  return useMutation<void, ApiResponseError, SignInFormData>({
+  return useMutation<LoginInfo, ApiResponseError, SignInFormData>({
     mutationKey: ["committeeSignIn"],
     mutationFn: postSignIn,
   });

--- a/src/hooks/tanstack-query/student/sign-in/index.ts
+++ b/src/hooks/tanstack-query/student/sign-in/index.ts
@@ -4,6 +4,7 @@ import { ROUTE } from "@/constants/routes";
 import { SignInFormData } from "@/types/common/sign-in";
 import { postSignIn } from "@/apis/common/sign-in";
 import { ApiResponseError } from "@/types/common/api";
+import { LoginInfo } from "@/apis/dtos/common/my-info";
 
 export const useStudentSignIn = () => {
   const router = useRouter();
@@ -15,8 +16,11 @@ export const useStudentSignIn = () => {
       onError: (error) => {
         alert(error.response.data.message || "로그인에 실패했습니다.");
       },
-      onSuccess: () => {
+      onSuccess: (data) => {
         queryClient.invalidateQueries({ queryKey: ["myInfo"] });
+        localStorage.setItem("accessToken", data.accessToken);
+        localStorage.setItem("refreshToken", data.refreshToken);
+
         router.push(ROUTE.STUDENT.DEPARTMENT_INFO);
         alert("로그인에 성공했습니다.");
       },
@@ -28,7 +32,7 @@ export const useStudentSignIn = () => {
 };
 
 export const useStudentSignInMutate = () => {
-  return useMutation<void, ApiResponseError, SignInFormData>({
+  return useMutation<LoginInfo, ApiResponseError, SignInFormData>({
     mutationKey: ["studentSignIn"],
     mutationFn: postSignIn,
   });


### PR DESCRIPTION
### 개요

close #74 

### 작업사항

- 로그인 방식 변경 (set-cookie를 header로 변경)

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 로그인 및 토큰 갱신 시 accessToken과 refreshToken이 반환되어 자동으로 저장됩니다.

- **버그 수정**
	- 로그인 및 토큰 재발급 과정에서 인증 토큰이 누락되는 문제를 해결했습니다.

- **리팩터**
	- 인증 요청 시 accessToken이 자동으로 헤더에 포함되도록 개선되었습니다.
	- 로그인 관련 반환 타입이 명확하게 변경되어 토큰 정보를 직접 활용할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->