### PR TITLE
refactor: lockerId, lockerId의 타입을 string으로 변경

### DIFF
--- a/src/apis/dtos/student/locker/index.ts
+++ b/src/apis/dtos/student/locker/index.ts
@@ -1,9 +1,9 @@
 export class Locker {
   available: boolean;
   code: string;
-  lockerId: number;
+  lockerId: string;
 
-  constructor({ available, code, lockerId }: { available: boolean; code: string; lockerId: number }) {
+  constructor({ available, code, lockerId }: { available: boolean; code: string; lockerId: string }) {
     this.available = available;
     this.code = code;
     this.lockerId = lockerId;
@@ -11,11 +11,11 @@ export class Locker {
 }
 
 export class LockerList {
-  floorId: number;
+  floorId: string;
   floorNumber: number;
   lockerList: Locker[];
 
-  constructor({ floorId, floorNumber, lockers }: { floorId: number; floorNumber: number; lockers: Locker[] }) {
+  constructor({ floorId, floorNumber, lockers }: { floorId: string; floorNumber: number; lockers: Locker[] }) {
     this.floorId = floorId;
     this.floorNumber = floorNumber;
     this.lockerList = lockers;

--- a/src/apis/student/apply-locker/index.ts
+++ b/src/apis/student/apply-locker/index.ts
@@ -5,7 +5,7 @@ export const getLockerList = async (eventId: string) => {
   const { data } = await https.get(`events/${eventId}/lockers`);
 
   const lockerList: LockerList[] = data.map(
-    ({ floorId, floorNumber, lockers }: { floorId: number; floorNumber: number; lockers: Locker[] }) =>
+    ({ floorId, floorNumber, lockers }: { floorId: string; floorNumber: number; lockers: Locker[] }) =>
       new LockerList({ floorId, floorNumber, lockers }),
   );
 
@@ -20,7 +20,7 @@ export const getMyRegistrationLocker = async (eventId: string) => {
 
 export interface ApplyLockerRequest {
   eventId: string;
-  lockerId: number;
+  lockerId: string;
 }
 
 export const postApplyLocker = async ({ eventId, lockerId }: ApplyLockerRequest) => {

--- a/src/components/page/student/ApplyLocker/LockerGrid/index.tsx
+++ b/src/components/page/student/ApplyLocker/LockerGrid/index.tsx
@@ -5,7 +5,7 @@ import LockerItem from "@/components/page/student/ApplyLocker/LockerItem/index";
 const cn = classNames.bind(styles);
 
 interface LockerGirdProps {
-  lockerList: { available: boolean; code: string; lockerId: number }[];
+  lockerList: { available: boolean; code: string; lockerId: string }[];
   className?: string;
 }
 


### PR DESCRIPTION
### 개요

close #132 

### 변경로직

- lockerId, lockerId의 타입을 string으로 변경

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- 사물함 및 층 ID 관련 속성들의 타입이 숫자에서 문자열로 변경되었습니다.  
	- 사물함 신청 및 목록 조회 시, 관련 ID 값의 데이터 타입이 문자열로 일관되게 적용됩니다.  
	- 사물함 그리드 컴포넌트의 props 중 lockerId의 타입이 문자열로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->