### PR TITLE
feat: api 응답 값의 데이터가 빈 값일 때 ui 표시

### DIFF
--- a/src/components/page/approve-wait/index.tsx
+++ b/src/components/page/approve-wait/index.tsx
@@ -66,7 +66,7 @@ export default function ApproveWait() {
                 <Skeleton className={cn("skeleton")} />
               </td>
             </tr>
-          ) : (
+          ) : approveWaitList.length > 0 ? (
             approveWaitList.map((approveWait) => (
               <tr key={approveWait.memberId} className={cn("tr")}>
                 <td className={cn("tableData")}>
@@ -103,6 +103,12 @@ export default function ApproveWait() {
                 </td>
               </tr>
             ))
+          ) : (
+            <tr className={cn("tr")}>
+              <td colSpan={5} className={cn("tableData")}>
+                <Txt size="h6">승인 대기 목록이 없습니다.</Txt>
+              </td>
+            </tr>
           )}
         </tbody>
       </table>

--- a/src/components/page/committee/announcement-list/index.tsx
+++ b/src/components/page/committee/announcement-list/index.tsx
@@ -61,16 +61,24 @@ export default function AnnouncementList() {
           </tbody>
         ) : (
           <tbody>
-            {announcementList.map((announcement) => (
-              <tr className={cn("tr")} key={announcement.id} onClick={() => onAnnouncementClick(announcement.id)}>
-                <td className={cn("tableData")}>
-                  <Txt size="h6">{announcement.title}</Txt>
-                </td>
-                <td className={cn("tableData")}>
-                  <Txt size="h6">{`${formatToKoreanTime(announcement.createdAt)}`}</Txt>
+            {announcementList.length > 0 ? (
+              announcementList.map((announcement) => (
+                <tr className={cn("tr")} key={announcement.id} onClick={() => onAnnouncementClick(announcement.id)}>
+                  <td className={cn("tableData")}>
+                    <Txt size="h6">{announcement.title}</Txt>
+                  </td>
+                  <td className={cn("tableData")}>
+                    <Txt size="h6">{`${formatToKoreanTime(announcement.createdAt)}`}</Txt>
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr className={cn("tr")}>
+                <td colSpan={3} className={cn("tableData")}>
+                  <Txt size="h6">공지사항이 없습니다.</Txt>
                 </td>
               </tr>
-            ))}
+            )}
           </tbody>
         )}
       </table>

--- a/src/components/page/committee/apply-list/index.tsx
+++ b/src/components/page/committee/apply-list/index.tsx
@@ -49,19 +49,27 @@ export default function ApplyList() {
           </tbody>
         ) : (
           <tbody>
-            {applyList.map((event) => (
-              <tr className={cn("tr")} key={event.id} onClick={() => onApplyClick(event.id)}>
-                <td className={cn("tableData")}>
-                  <Txt size="h6">{event.title}</Txt>
-                </td>
-                <td className={cn("tableData")}>
-                  <Txt size="h6">{`${formatToKoreanTime(event.startAt)} ~ ${formatToKoreanTime(event.endAt)}`}</Txt>
-                </td>
-                <td className={cn("tableData")}>
-                  <Txt size="h6">{event.status}</Txt>
+            {applyList.length > 0 ? (
+              applyList.map((event) => (
+                <tr className={cn("tr")} key={event.id} onClick={() => onApplyClick(event.id)}>
+                  <td className={cn("tableData")}>
+                    <Txt size="h6">{event.title}</Txt>
+                  </td>
+                  <td className={cn("tableData")}>
+                    <Txt size="h6">{`${formatToKoreanTime(event.startAt)} ~ ${formatToKoreanTime(event.endAt)}`}</Txt>
+                  </td>
+                  <td className={cn("tableData")}>
+                    <Txt size="h6">{event.status}</Txt>
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr className={cn("tr")}>
+                <td colSpan={3} className={cn("tableData")}>
+                  <Txt size="h6">신청 목록이 없습니다.</Txt>
                 </td>
               </tr>
-            ))}
+            )}
           </tbody>
         )}
       </table>

--- a/src/components/page/committee/event-list/index.tsx
+++ b/src/components/page/committee/event-list/index.tsx
@@ -75,7 +75,7 @@ export default function EventList() {
                 <Skeleton className={cn("skeleton")} />
               </td>
             </tr>
-          ) : (
+          ) : eventList.length > 0 ? (
             eventList.map((event) => (
               <tr key={event.id} className={cn("tr")} onClick={() => onEventClick(event.id)}>
                 <td className={cn("tableData")}>
@@ -116,6 +116,12 @@ export default function EventList() {
                 </td>
               </tr>
             ))
+          ) : (
+            <tr className={cn("tr")}>
+              <td colSpan={5} className={cn("tableData")}>
+                <Txt size="h6">이벤트가 없습니다.</Txt>
+              </td>
+            </tr>
           )}
         </tbody>
       </table>

--- a/src/components/page/student/DepartmentInfo/DepartmentInfoAnnouncement/index.tsx
+++ b/src/components/page/student/DepartmentInfo/DepartmentInfoAnnouncement/index.tsx
@@ -27,11 +27,17 @@ export default function DepartmentInfoAnnouncement() {
         공지사항
       </Txt>
       <div className={cn("announcementContainer")}>
-        <Link href={`${ROUTE.STUDENT.MY_ANNOUNCEMENT}/${data.content[0].id}`}>
+        {data.content.length >= 1 ? (
+          <Link href={`${ROUTE.STUDENT.MY_ANNOUNCEMENT}/${data.content[0].id}`}>
+            <Txt className={cn("announcement")} size="h4">
+              {data.content[0].title}
+            </Txt>
+          </Link>
+        ) : (
           <Txt className={cn("announcement")} size="h4">
-            {data.content[0].title}
+            공지사항이 없습니다.
           </Txt>
-        </Link>
+        )}
       </div>
       <div className={cn("moreLinkContainer")}>
         <Link href={ROUTE.STUDENT.MY_ANNOUNCEMENT_LIST}>

--- a/src/components/page/student/DepartmentInfo/DepartmentInfoApplyLocker/index.module.scss
+++ b/src/components/page/student/DepartmentInfo/DepartmentInfoApplyLocker/index.module.scss
@@ -6,6 +6,12 @@
   @include flexSort(column, null, null, 1.5rem);
 }
 
+.noEvent {
+  border-radius: 1rem;
+  border: 0.1rem solid #ddd;
+  padding: 2rem;
+}
+
 .moreLinkContainer {
   @include flexSort(row, flex-end, null, null);
 }

--- a/src/components/page/student/DepartmentInfo/DepartmentInfoApplyLocker/index.tsx
+++ b/src/components/page/student/DepartmentInfo/DepartmentInfoApplyLocker/index.tsx
@@ -29,7 +29,13 @@ export default function DepartmentInfoApplyLocker() {
       <Txt color="secondary" weight="bold" size="h3">
         사물함 신청
       </Txt>
-      <MyLockerEventCarousel myEventList={data.content} options={OPTIONS} />
+      {data.content.length >= 1 ? (
+        <MyLockerEventCarousel myEventList={data.content} options={OPTIONS} />
+      ) : (
+        <Txt className={cn("noEvent")} size="h5">
+          사물함 신청 이벤트가 없습니다.
+        </Txt>
+      )}
       <div className={cn("moreLinkContainer")}>
         <Link href={ROUTE.STUDENT.MY_EVENT_LIST}>
           <Txt size="tiny" className={cn("moreLink")}>

--- a/src/components/page/student/my-announcement-list/index.tsx
+++ b/src/components/page/student/my-announcement-list/index.tsx
@@ -57,26 +57,36 @@ export default function MyAnnouncementList() {
           </tbody>
         ) : (
           <tbody>
-            {myAnnouncementList.map((myAnnouncement) => (
-              <tr className={cn("tr")} key={myAnnouncement.id} onClick={() => onAnnouncementClick(myAnnouncement.id)}>
-                <td className={cn("tableData")}>
+            {myAnnouncementList.length > 0 ? (
+              myAnnouncementList.map((myAnnouncement) => (
+                <tr className={cn("tr")} key={myAnnouncement.id} onClick={() => onAnnouncementClick(myAnnouncement.id)}>
+                  <td className={cn("tableData")}>
+                    <Txt size="h6" className={cn("tableBodyTitle")}>
+                      {myAnnouncement.title}
+                    </Txt>
+                  </td>
+                  <td className={cn("tableData")}>
+                    <Txt size="h6" className={cn("tableBodyTitle")}>
+                      {myAnnouncement.writer}
+                    </Txt>
+                  </td>
+                  <td className={cn("tableData")}>
+                    <Txt
+                      size="h6"
+                      className={cn("tableBodyTitle")}
+                    >{`${formatToKoreanTime(myAnnouncement.createdAt)}`}</Txt>
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr className={cn("tr")}>
+                <td colSpan={3} className={cn("tableData")}>
                   <Txt size="h6" className={cn("tableBodyTitle")}>
-                    {myAnnouncement.title}
+                    공지사항이 없습니다.
                   </Txt>
-                </td>
-                <td className={cn("tableData")}>
-                  <Txt size="h6" className={cn("tableBodyTitle")}>
-                    {myAnnouncement.writer}
-                  </Txt>
-                </td>
-                <td className={cn("tableData")}>
-                  <Txt
-                    size="h6"
-                    className={cn("tableBodyTitle")}
-                  >{`${formatToKoreanTime(myAnnouncement.createdAt)}`}</Txt>
                 </td>
               </tr>
-            ))}
+            )}
           </tbody>
         )}
       </table>

--- a/src/components/page/student/my-event-list/index.tsx
+++ b/src/components/page/student/my-event-list/index.tsx
@@ -49,26 +49,36 @@ export default function MyEventList() {
           </tbody>
         ) : (
           <tbody>
-            {myEventList.map((myEvent) => (
-              <tr className={cn("tr")} key={myEvent.id} onClick={() => onEventClick(myEvent.id)}>
-                <td className={cn("tableData")}>
+            {myEventList.length > 0 ? (
+              myEventList.map((myEvent) => (
+                <tr className={cn("tr")} key={myEvent.id} onClick={() => onEventClick(myEvent.id)}>
+                  <td className={cn("tableData")}>
+                    <Txt size="h6" className={cn("tableBodyTitle")}>
+                      {myEvent.title}
+                    </Txt>
+                  </td>
+                  <td className={cn("tableData")}>
+                    <Txt size="h6" className={cn("tableBodyTitle")}>
+                      {myEvent.departmentNickname}
+                    </Txt>
+                  </td>
+                  <td className={cn("tableData")}>
+                    <Txt
+                      size="h6"
+                      className={cn("tableBodyTitle")}
+                    >{`${formatToKoreanTime(myEvent.startAt)} ~ ${formatToKoreanTime(myEvent.endAt)}`}</Txt>
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr className={cn("tr")}>
+                <td colSpan={3} className={cn("tableData")}>
                   <Txt size="h6" className={cn("tableBodyTitle")}>
-                    {myEvent.title}
+                    이벤트가 없습니다.
                   </Txt>
-                </td>
-                <td className={cn("tableData")}>
-                  <Txt size="h6" className={cn("tableBodyTitle")}>
-                    {myEvent.departmentNickname}
-                  </Txt>
-                </td>
-                <td className={cn("tableData")}>
-                  <Txt
-                    size="h6"
-                    className={cn("tableBodyTitle")}
-                  >{`${formatToKoreanTime(myEvent.startAt)} ~ ${formatToKoreanTime(myEvent.endAt)}`}</Txt>
                 </td>
               </tr>
-            ))}
+            )}
           </tbody>
         )}
       </table>


### PR DESCRIPTION
### 개요

close #134 

### 작업사항

- api 응답 값의 데이터가 빈 값일 때 ui 표시

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 승인 대기 목록, 공지사항 목록, 신청 목록, 이벤트 목록, 학과 공지사항, 사물함 신청 이벤트, 내 공지사항, 내 이벤트 목록 등에서 데이터가 없을 때 명확한 안내 메시지가 표시됩니다.
- **스타일**
  - 사물함 신청 이벤트의 빈 상태 메시지에 테두리, 패딩 등 시각적 스타일이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->