### PR TITLE
feat: 나의 사물함 신청 테이블에 신청 정보가 없을 시 신청 정보가 없다는 ui 표시

### DIFF
--- a/src/components/page/student/ApplyLocker/ApplyLockerStatusTable/index.tsx
+++ b/src/components/page/student/ApplyLocker/ApplyLockerStatusTable/index.tsx
@@ -9,10 +9,37 @@ import Skeleton from "@/components/common/Skeleton";
 const cn = classNames.bind(styles);
 
 export default function ApplyLockerStatusTable() {
-  const { myRegistrationLocker, onDeleteMyRegistrationLocker, isPending, isError } = useMyRegistrationLocker();
+  const { myRegistrationLocker, onDeleteMyRegistrationLocker, isPending, isError, error } = useMyRegistrationLocker();
 
   if (isPending) {
     return <Skeleton className={cn("skeleton")} />;
+  }
+
+  if (error?.response.status === 404) {
+    return (
+      <table className={cn("container")}>
+        <thead>
+          <tr className={cn("header")}>
+            <th className={cn("th")}>
+              <Txt weight="semiBold">층수</Txt>
+            </th>
+            <th className={cn("th")}>
+              <Txt weight="semiBold">사물함 번호</Txt>
+            </th>
+            <th className={cn("th")}>
+              <Txt weight="semiBold">삭제</Txt>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td colSpan={3} className={cn("td")}>
+              <Txt size="h6">신청 내역이 없습니다.</Txt>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    );
   }
 
   if (isError) {

--- a/src/components/page/student/ApplyLocker/LockerApplicationStatus/index.tsx
+++ b/src/components/page/student/ApplyLocker/LockerApplicationStatus/index.tsx
@@ -11,7 +11,7 @@ import { useLockerList } from "@/hooks/student/apply-locker/useLockerList";
 const cn = classNames.bind(styles);
 
 export default function LockerApplicationStatus() {
-  const { selectedLockerList, floorList, selectedFloor, onSelectFloor } = useLockerList();
+  const { selectedLockerList, floorList, selectedFloor, onSelectFloor, isLockerLoading } = useLockerList();
 
   return (
     <div className={cn("container")}>
@@ -23,7 +23,7 @@ export default function LockerApplicationStatus() {
         <div className={cn("lockerStatusContainer")}>
           <LockerStatusLegend />
         </div>
-        <LockerGrid lockerList={selectedLockerList} className={cn("gridContainer")} />
+        <LockerGrid isLockerLoading={isLockerLoading} lockerList={selectedLockerList} className={cn("gridContainer")} />
       </div>
     </div>
   );

--- a/src/components/page/student/ApplyLocker/LockerGrid/index.module.scss
+++ b/src/components/page/student/ApplyLocker/LockerGrid/index.module.scss
@@ -1,3 +1,20 @@
+.skeleton {
+  width: 100%;
+  height: 20rem;
+
+  @include tablet {
+    height: 20rem;
+  }
+
+  @include smallDesktop {
+    height: 30rem;
+  }
+
+  @include desktop {
+    height: 40rem;
+  }
+}
+
 .container {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/src/components/page/student/ApplyLocker/LockerGrid/index.module.scss
+++ b/src/components/page/student/ApplyLocker/LockerGrid/index.module.scss
@@ -2,10 +2,6 @@
   width: 100%;
   height: 20rem;
 
-  @include tablet {
-    height: 20rem;
-  }
-
   @include smallDesktop {
     height: 30rem;
   }

--- a/src/components/page/student/ApplyLocker/LockerGrid/index.tsx
+++ b/src/components/page/student/ApplyLocker/LockerGrid/index.tsx
@@ -1,15 +1,21 @@
 import classNames from "classnames/bind";
 import styles from "./index.module.scss";
 import LockerItem from "@/components/page/student/ApplyLocker/LockerItem/index";
+import Skeleton from "@/components/common/Skeleton";
 
 const cn = classNames.bind(styles);
 
 interface LockerGirdProps {
   lockerList: { available: boolean; code: string; lockerId: string }[];
   className?: string;
+  isLockerLoading: boolean;
 }
 
-export default function LockerGrid({ lockerList, className }: LockerGirdProps) {
+export default function LockerGrid({ lockerList, className, isLockerLoading }: LockerGirdProps) {
+  if (isLockerLoading) {
+    return <Skeleton className={cn("skeleton")} />;
+  }
+
   return (
     <div className={cn("container", className)}>
       {lockerList.map(({ code, available, lockerId }) => (

--- a/src/hooks/student/apply-locker/useLockerList.ts
+++ b/src/hooks/student/apply-locker/useLockerList.ts
@@ -5,7 +5,7 @@ import { useLockerFloor } from "./useLockerFloor";
 export const useLockerList = () => {
   const { eventId } = useGetApplyLockerPageEventId();
 
-  const { data: lockerInfo } = useGetLockerList(eventId);
+  const { data: lockerInfo, isPending } = useGetLockerList(eventId);
 
   const floorList = lockerInfo?.map((floor) => floor.floorNumber) || [];
 
@@ -19,5 +19,6 @@ export const useLockerList = () => {
     selectedFloor,
     onSelectFloor,
     selectedLockerList,
+    isLockerLoading: isPending,
   };
 };

--- a/src/hooks/student/apply-locker/useMyRegistrationLocker.ts
+++ b/src/hooks/student/apply-locker/useMyRegistrationLocker.ts
@@ -5,7 +5,7 @@ import { useGetMyRegistrationLocker } from "@/hooks/tanstack-query/student/apply
 export const useMyRegistrationLocker = () => {
   const { eventId } = useGetApplyLockerPageEventId();
 
-  const { data: myRegistrationLocker, isPending, isError } = useGetMyRegistrationLocker(eventId);
+  const { data: myRegistrationLocker, isPending, isError, error } = useGetMyRegistrationLocker(eventId);
 
   const { onDeleteMyRegistrationLocker } = useDeleteMyRegistrationLocker(eventId);
 
@@ -14,5 +14,6 @@ export const useMyRegistrationLocker = () => {
     onDeleteMyRegistrationLocker,
     isPending,
     isError,
+    error,
   };
 };

--- a/src/hooks/tanstack-query/student/apply-locker/useGetMyRegistrationLocker.ts
+++ b/src/hooks/tanstack-query/student/apply-locker/useGetMyRegistrationLocker.ts
@@ -1,8 +1,10 @@
+import { MyRegistrationLocker } from "@/apis/dtos/student/locker";
 import { getMyRegistrationLocker } from "@/apis/student/apply-locker";
+import { ApiResponseError } from "@/types/common/api";
 import { useQuery } from "@tanstack/react-query";
 
 export const useGetMyRegistrationLocker = (eventId: string) => {
-  return useQuery({
+  return useQuery<MyRegistrationLocker, ApiResponseError>({
     queryKey: ["myRegistrationLocker", eventId],
     queryFn: () => getMyRegistrationLocker(eventId),
     enabled: !!eventId,


### PR DESCRIPTION
### 개요

close #143 

### 작업사항

- 나의 사물함 신청 테이블에 신청 정보가 없을 시 신청 정보가 없다는 ui 표시
- 사물함을 불러오는 동안 로딩 처리

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사물함 목록 로딩 시 스켈레톤(로딩) 화면이 표시됩니다.
  - 사물함 신청 내역이 없을 경우, "신청 내역이 없습니다." 메시지가 표로 안내됩니다.

- **스타일**
  - 스켈레톤(로딩) 화면에 반응형 높이 스타일이 적용되었습니다.

- **버그 수정**
  - 사물함 신청 내역 조회 시 404 에러를 명확하게 안내합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->