### PR TITLE
refactor: 학생용 페이지에서 로고 클릭 시 학과 정보 페이지로 이동

### DIFF
--- a/src/components/common/ApplyHeader/index.tsx
+++ b/src/components/common/ApplyHeader/index.tsx
@@ -9,7 +9,7 @@ const cn = classNames.bind(styles);
 export default function ApplyHeader() {
   return (
     <header className={cn("header")}>
-      <Link href={ROUTE.STUDENT.MAIN}>
+      <Link href={ROUTE.STUDENT.DEPARTMENT_INFO}>
         <StudentLogo width={100} height={50} />
       </Link>
     </header>


### PR DESCRIPTION
### 개요

close #147 

### 작업사항

- 학생용 페이지에서 로고 클릭 시 학과 정보 페이지로 이동


### 체크리스트

- [x] assignees 설정
- [x]label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - ApplyHeader에서 StudentLogo 클릭 시 이동하는 링크가 학생 메인 페이지에서 학과 정보 페이지로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->