### PR TITLE
feat: 이벤트 게시 상태 변경 시 스피너 ui 처리

### DIFF
--- a/src/components/page/committee/event-list/index.tsx
+++ b/src/components/page/committee/event-list/index.tsx
@@ -10,6 +10,7 @@ import { formatToKoreanTime } from "@/utils/date";
 import Link from "next/link";
 import { ROUTE } from "@/constants/routes";
 import Skeleton from "@/components/common/Skeleton";
+import Spinner from "@/components/common/Spinner";
 
 const cn = classNames.bind(styles);
 
@@ -24,114 +25,120 @@ export default function EventList() {
     onChangeEventPublish,
     isLoading,
     onEventClick,
+    isChangeEventLoading,
   } = useEventList();
 
   return (
-    <div className={cn("container")}>
-      <div className={cn("header")}>
-        <Txt color="primary" size="h3" weight="medium">
-          이벤트 목록
-        </Txt>
-        <Link href={ROUTE.COMMITTEE.CREATE_EVENT} className={cn("createEvent")}>
-          <Txt color="white" size="h6">
-            이벤트 생성
+    <>
+      <div className={cn("container")}>
+        <div className={cn("header")}>
+          <Txt color="primary" size="h3" weight="medium">
+            이벤트 목록
           </Txt>
-        </Link>
-      </div>
-      <table>
-        <thead className={cn("tableHeaderContainer")}>
-          <tr>
-            <th className={cn("tableHeader")}>
-              <Txt color="white" weight="medium">
-                이벤트명
-              </Txt>
-            </th>
-            <th className={cn("tableHeader")}>
-              <Txt color="white" weight="medium">
-                이벤트 기간
-              </Txt>
-            </th>
-            <th className={cn("tableHeader")}>
-              <Txt color="white" weight="medium">
-                상태
-              </Txt>
-            </th>
-            <th className={cn("tableHeader")}>
-              <Txt color="white" weight="medium">
-                게시 상태
-              </Txt>
-            </th>
-            <th className={cn("tableHeader")}>
-              <Txt color="white" weight="medium">
-                게시
-              </Txt>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {isLoading ? (
+          <Link href={ROUTE.COMMITTEE.CREATE_EVENT} className={cn("createEvent")}>
+            <Txt color="white" size="h6">
+              이벤트 생성
+            </Txt>
+          </Link>
+        </div>
+        <table>
+          <thead className={cn("tableHeaderContainer")}>
             <tr>
-              <td colSpan={6}>
-                <Skeleton className={cn("skeleton")} />
-              </td>
+              <th className={cn("tableHeader")}>
+                <Txt color="white" weight="medium">
+                  이벤트명
+                </Txt>
+              </th>
+              <th className={cn("tableHeader")}>
+                <Txt color="white" weight="medium">
+                  이벤트 기간
+                </Txt>
+              </th>
+              <th className={cn("tableHeader")}>
+                <Txt color="white" weight="medium">
+                  상태
+                </Txt>
+              </th>
+              <th className={cn("tableHeader")}>
+                <Txt color="white" weight="medium">
+                  게시 상태
+                </Txt>
+              </th>
+              <th className={cn("tableHeader")}>
+                <Txt color="white" weight="medium">
+                  게시
+                </Txt>
+              </th>
             </tr>
-          ) : eventList.length > 0 ? (
-            eventList.map((event) => (
-              <tr key={event.id} className={cn("tr")} onClick={() => onEventClick(event.id)}>
-                <td className={cn("tableData")}>
-                  <Txt size="h6">{event.title}</Txt>
-                </td>
-                <td className={cn("tableData")}>
-                  <Txt size="h6">{`${formatToKoreanTime(event.startAt)} ~ ${formatToKoreanTime(event.endAt)}`}</Txt>
-                </td>
-                <td className={cn("tableData")}>
-                  <Txt size="h6">{event.status}</Txt>
-                </td>
-                <td className={cn("tableData")}>
-                  <Txt size="h6">{event.publish === true ? "공개" : "비공개"}</Txt>
-                </td>
-                <td className={cn("tableData", "publish")}>
-                  <Button
-                    color="primary"
-                    className={cn("btn")}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onChangeEventPublish(event.id, true);
-                    }}
-                  >
-                    <Txt color="white" size="h6">
-                      공개
-                    </Txt>
-                  </Button>
-                  <Button
-                    color="gray"
-                    className={cn("btn")}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onChangeEventPublish(event.id, false);
-                    }}
-                  >
-                    <Txt size="h6">비공개</Txt>
-                  </Button>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <tr>
+                <td colSpan={6}>
+                  <Skeleton className={cn("skeleton")} />
                 </td>
               </tr>
-            ))
-          ) : (
-            <tr className={cn("tr")}>
-              <td colSpan={5} className={cn("tableData")}>
-                <Txt size="h6">이벤트가 없습니다.</Txt>
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </table>
-      <Pagination
-        pagesPerGroup={pagesPerGroup}
-        currentPage={currentPage}
-        itemsPerPage={itemsPerPage}
-        totalItems={totalElements}
-        setPage={setPage}
-      />
-    </div>
+            ) : eventList.length > 0 ? (
+              eventList.map((event) => (
+                <tr key={event.id} className={cn("tr")} onClick={() => onEventClick(event.id)}>
+                  <td className={cn("tableData")}>
+                    <Txt size="h6">{event.title}</Txt>
+                  </td>
+                  <td className={cn("tableData")}>
+                    <Txt size="h6">{`${formatToKoreanTime(event.startAt)} ~ ${formatToKoreanTime(event.endAt)}`}</Txt>
+                  </td>
+                  <td className={cn("tableData")}>
+                    <Txt size="h6">{event.status}</Txt>
+                  </td>
+                  <td className={cn("tableData")}>
+                    <Txt size="h6">{event.publish === true ? "공개" : "비공개"}</Txt>
+                  </td>
+                  <td className={cn("tableData", "publish")}>
+                    <Button
+                      color="primary"
+                      className={cn("btn")}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onChangeEventPublish(event.id, true);
+                      }}
+                      disabled={isChangeEventLoading}
+                    >
+                      <Txt color="white" size="h6">
+                        공개
+                      </Txt>
+                    </Button>
+                    <Button
+                      color="gray"
+                      className={cn("btn")}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onChangeEventPublish(event.id, false);
+                      }}
+                      disabled={isChangeEventLoading}
+                    >
+                      <Txt size="h6">비공개</Txt>
+                    </Button>
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr className={cn("tr")}>
+                <td colSpan={5} className={cn("tableData")}>
+                  <Txt size="h6">이벤트가 없습니다.</Txt>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+        <Pagination
+          pagesPerGroup={pagesPerGroup}
+          currentPage={currentPage}
+          itemsPerPage={itemsPerPage}
+          totalItems={totalElements}
+          setPage={setPage}
+        />
+      </div>
+      {isChangeEventLoading && <Spinner />}
+    </>
   );
 }

--- a/src/hooks/committee/event/useEventList.ts
+++ b/src/hooks/committee/event/useEventList.ts
@@ -15,7 +15,7 @@ export const useEventList = () => {
   const { data, isLoading, isError, error } = useGetEventListQuery(queryParams);
   useCommitteeCertification(isError, error as ApiResponseError);
 
-  const { onChangeEventPublish } = usePutEventPublish(queryParams);
+  const { onChangeEventPublish, isChangeEventLoading } = usePutEventPublish(queryParams);
 
   const eventList = data?.content || [];
   const totalElements = data?.totalElements || 0;
@@ -34,5 +34,6 @@ export const useEventList = () => {
     onChangeEventPublish,
     isLoading,
     onEventClick,
+    isChangeEventLoading,
   };
 };

--- a/src/hooks/tanstack-query/committee/event/usePutEventPublish.ts
+++ b/src/hooks/tanstack-query/committee/event/usePutEventPublish.ts
@@ -9,7 +9,7 @@ interface usePutEventPublishParams {
 }
 
 export const usePutEventPublish = ({ page, size, direction }: usePutEventPublishParams) => {
-  const { mutate } = usePutEventPublishMutate();
+  const { mutate, isPending } = usePutEventPublishMutate();
   const queryClient = useQueryClient();
 
   const onChangeEventPublish = (id: string, isPublish: boolean) => {
@@ -29,6 +29,7 @@ export const usePutEventPublish = ({ page, size, direction }: usePutEventPublish
 
   return {
     onChangeEventPublish,
+    isChangeEventLoading: isPending,
   };
 };
 


### PR DESCRIPTION
### 개요

close #155 

### 작업사항

- 이벤트 게시 상태 변경 시 스피너 ui 처리

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 이벤트 공개/비공개 전환 시 로딩 상태를 표시하는 스피너가 추가되었습니다.
  - 이벤트 공개/비공개 토글 버튼이 로딩 중일 때 비활성화되어 중복 클릭을 방지합니다.

- **버그 수정**
  - 테이블 헤더가 올바른 위치(테이블 상단)로 이동하여 구조가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->