### PR TITLE
refactor: 엑셀 파일의 내용을 층수를 기준으로 오름차순, 층수가 같으면 사물함 이름으로 오름차순으로 변경

### DIFF
--- a/src/hooks/committee/apply/useApplyDetail.ts
+++ b/src/hooks/committee/apply/useApplyDetail.ts
@@ -23,16 +23,24 @@ export const useApplyDetail = () => {
   });
 
   const excelData =
-    excel?.content.map((applyDetail, idx) => ({
-      순번: idx + 1,
-      층수: applyDetail.floorNumber,
-      "사물함 이름": applyDetail.lockerCode,
-      학번: applyDetail.member.studentNumber,
-      소속: applyDetail.member.organization,
-      학과: applyDetail.member.department,
-      이름: applyDetail.member.name,
-      이메일: applyDetail.member.email,
-    })) || [];
+    excel?.content
+      .slice()
+      .sort((a, b) => {
+        if (a.floorNumber !== b.floorNumber) {
+          return a.floorNumber - b.floorNumber;
+        }
+
+        return a.lockerCode.localeCompare(b.lockerCode, undefined, { numeric: true });
+      })
+      .map((applyDetail) => ({
+        층수: `${applyDetail.floorNumber}층`,
+        "사물함 이름": applyDetail.lockerCode,
+        학번: applyDetail.member.studentNumber,
+        소속: applyDetail.member.organization,
+        학과: applyDetail.member.department,
+        이름: applyDetail.member.name,
+        이메일: applyDetail.member.email,
+      })) || [];
 
   useCommitteeCertification(isError, error as ApiResponseError);
 


### PR DESCRIPTION
### 개요

close #170 

### 변경로직

- 엑셀 파일의 내용을 층수를 기준으로 오름차순, 층수가 같으면 사물함 이름으로 오름차순으로 변경

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
    - 엑셀 데이터가 이제 층 번호 오름차순 및 사물함 코드 순으로 정렬되어 표시됩니다.
    - 층 번호가 "층" 접미사와 함께 문자열로 표시됩니다.
    - 순번(인덱스) 컬럼이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->