### PR TITLE
feat: 사물함 생성 validation 추가 및 생성 api 에러 처리 추가

### DIFF
--- a/src/constants/error/validationTypes.ts
+++ b/src/constants/error/validationTypes.ts
@@ -4,4 +4,6 @@ export const VALIDATION_TYPES = {
   MATCH: "match",
   DUPLICATE: "duplicate",
   MIN: "min",
+  MAX: "max",
+  RANGE: "range",
 } as const;

--- a/src/constants/validation/createEvent.ts
+++ b/src/constants/validation/createEvent.ts
@@ -26,5 +26,7 @@ export const CREATE_EVENT_VALIDATION = {
   },
   lockerNumber: {
     [VALIDATION_TYPES.REQUIRED]: "사물함 번호를 입력해주세요.",
+    [VALIDATION_TYPES.RANGE]: "사물함 시작 번호는 끝 번호보다 작거나 같아야 합니다.",
+    [VALIDATION_TYPES.MAX]: "사물함 범위가 너무 큽니다. 최대 2000개까지 가능합니다.",
   },
 };

--- a/src/functions/validator/createEventValidator.ts
+++ b/src/functions/validator/createEventValidator.ts
@@ -34,5 +34,37 @@ export const createEventValidator = (formData: CreateEventForm) => {
     return CREATE_EVENT_VALIDATION.lockerNumber.required;
   }
 
+  const invalidLockerRange = formData.floors.find((floor) =>
+    floor.prefixes.some((prefix) =>
+      prefix.ranges.some((range) => {
+        const start = Number(range.lockerStartNumber);
+        const end = Number(range.lockerEndNumber);
+
+        return start > end;
+      }),
+    ),
+  );
+
+  if (invalidLockerRange) {
+    return CREATE_EVENT_VALIDATION.lockerNumber.range;
+  }
+
+  const invalidLockerCount = formData.floors.find((floor) =>
+    floor.prefixes.some((prefix) =>
+      prefix.ranges.some((range) => {
+        const start = Number(range.lockerStartNumber);
+        const end = Number(range.lockerEndNumber);
+        const maxLockerNumber = 2000;
+
+        const count = end - start + 1;
+        return count > maxLockerNumber;
+      }),
+    ),
+  );
+
+  if (invalidLockerCount) {
+    return CREATE_EVENT_VALIDATION.lockerNumber.max;
+  }
+
   return null;
 };

--- a/src/hooks/tanstack-query/committee/event/useCreateEvent.ts
+++ b/src/hooks/tanstack-query/committee/event/useCreateEvent.ts
@@ -18,6 +18,14 @@ export const useCreateEvent = () => {
   const onCreateEvent = (formData: CreateEventRequest) => {
     mutate(formData, {
       onError: (error) => {
+        const invalidParams = error.response.data.invalidParams;
+        if (invalidParams && invalidParams.length > 0) {
+          invalidParams.forEach(({ message }) => {
+            alert(message);
+          });
+          return;
+        }
+
         alert(error.response.data.message || "이벤트 생성에 실패하였습니다.");
       },
       onSuccess: () => {

--- a/src/types/common/api/index.ts
+++ b/src/types/common/api/index.ts
@@ -4,6 +4,10 @@ export interface ApiResponseError {
     data: {
       message: string;
       code: string;
+      invalidParams?: {
+        field: string;
+        message: string;
+      }[];
     };
   };
 }


### PR DESCRIPTION
### 개요

close #173 

### 작업사항

- 사물함 생성 시 시작 범위가 끝 범위보다 작거나 같아야 한다.
- 사물함 생성 시 시작 범위와 끝 범위의 차이가 2000이하여야 한다.
- 사물함 생성 api 응답 실패 시 invalidParams가 있으면 invalidParams의 message 출력

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 이벤트 생성 시 사물함 번호 범위에 대한 유효성 검사(시작 번호가 종료 번호보다 클 수 없음, 최대 2000개 제한)가 추가되었습니다.
  - 사물함 번호 범위 오류 발생 시, 구체적인 오류 메시지가 화면에 표시됩니다.

- **버그 수정**
  - 이벤트 생성 중 잘못된 입력값이 있을 때, 상세 오류 메시지가 개별적으로 안내됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->