### PR TITLE
refactor: 사물함 신청 api, 나의 사물함 신청 취소 api 요청에 대해 onSettled 일 때 사물함 신청 현황과 나의 사물함 신청 현황 api를 다시 불러오기

### DIFF
--- a/src/hooks/tanstack-query/student/apply-locker/useDeleteMyRegistrationLocker.ts
+++ b/src/hooks/tanstack-query/student/apply-locker/useDeleteMyRegistrationLocker.ts
@@ -12,9 +12,11 @@ export const useDeleteMyRegistrationLocker = (eventId: string) => {
         alert(error.response.data.message || "사물함 신청 취소에 실패했습니다.");
       },
       onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: ["lockerList", eventId] });
-        queryClient.invalidateQueries({ queryKey: ["myRegistrationLocker", eventId] });
         alert("사물함 신청이 취소되었습니다.");
+      },
+      onSettled: () => {
+        queryClient.invalidateQueries({ queryKey: ["myRegistrationLocker", eventId] });
+        queryClient.invalidateQueries({ queryKey: ["lockerList", eventId] });
       },
     });
   };

--- a/src/hooks/tanstack-query/student/apply-locker/usePostApplyLocker.ts
+++ b/src/hooks/tanstack-query/student/apply-locker/usePostApplyLocker.ts
@@ -30,9 +30,11 @@ export const usePostApplyLocker = () => {
           alert(error.response.data.message || "사물함 신청에 실패했습니다.");
         },
         onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: ["lockerList", eventId] });
-          queryClient.invalidateQueries({ queryKey: ["myRegistrationLocker", eventId] });
           alert("사물함 신청에 성공하셨습니다.");
+        },
+        onSettled: () => {
+          queryClient.invalidateQueries({ queryKey: ["myRegistrationLocker", eventId] });
+          queryClient.invalidateQueries({ queryKey: ["lockerList", eventId] });
         },
       },
     );


### PR DESCRIPTION
### 개요

close #178 

### 작업사항

- 사물함 신청 api, 나의 사물함 신청 취소 api 요청에 대해 onSettled 일 때 사물함 신청 현황과 나의 사물함 신청 현황 api를 다시 불러오기

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 사물함 신청 및 등록 취소 후, 성공 여부와 관계없이 목록이 항상 최신 상태로 갱신되도록 개선되었습니다.
  * 신청 또는 취소 성공 시 알림은 기존과 동일하게 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->