### PR TITLE
design: 이벤트 게시 상태 변경 UI 변경

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,1 +1,88 @@
-if(!self.define){let e,s={};const c=(c,i)=>(c=new URL(c+".js",i).href,s[c]||new Promise(s=>{if("document"in self){const e=document.createElement("script");e.src=c,e.onload=s,document.head.appendChild(e)}else e=c,importScripts(c),s()}).then(()=>{let e=s[c];if(!e)throw new Error(`Module ${c} didn’t register its module`);return e}));self.define=(i,n)=>{const t=e||("document"in self?document.currentScript.src:"")||location.href;if(s[t])return;let a={};const r=e=>c(e,t),o={module:{uri:t},exports:a,require:r};s[t]=Promise.all(i.map(e=>o[e]||r(e))).then(e=>(n(...e),a))}}define(["./workbox-f1770938"],function(e){"use strict";importScripts(),self.skipWaiting(),e.clientsClaim(),e.precacheAndRoute([{url:"/_next/static/Diyy8M36gApXRdKf3hm2c/_buildManifest.js",revision:"f3a57de38a00bfe438156382e5410b86"},{url:"/_next/static/Diyy8M36gApXRdKf3hm2c/_ssgManifest.js",revision:"b6652df95db52feb4daf4eca35380933"},{url:"/_next/static/chunks/1144-b3007e1e10bc19f4.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/13633bf0-4a562ad1a09beaeb.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/2170a4aa-8be2e1de3df20b60.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/2721-03c044502096677a.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/4bd1b696-9ed1a5b5c858620a.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/6663-b3ae6909b7954ea1.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/6874-f7c61052a27dcb1f.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/8886-f7f5e1d9b636024a.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/9360-5fba426bf9767ff7.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/9373-e7f1467f048dcafa.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/9400-d20064d943009feb.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/960-20ed135cd1ccbdb6.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/_not-found/page-1408d751b9feb5f7.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/committee/announcement-list/page-2d2d1c83111e8e15.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/committee/announcement/%5BannouncementId%5D/page-4bdd6f197d6cbc72.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/committee/apply-list/%5Bevent-id%5D/page-1a53577f64696a71.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/committee/apply-list/page-103f8d89bd03d27b.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/committee/approve-wait/page-f6fd7e1a62057ba1.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/committee/create-announcement/page-bc7f9171ebc575e8.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/committee/create-event/page-64e1b46e3a8cbe6c.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/committee/event-list/page-4eb40127050daea8.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/committee/event/%5BeventId%5D/page-331b505cb600abec.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/committee/layout-2cdfb3788197a54e.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/committee/page-afa5609ce6f3520f.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/committee/sign-up/page-0d118055af18f6a5.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/layout-1026ee78b5073bf3.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/page-8c6704bd209c4b8c.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/student/apply-locker/%5Bevent-id%5D/page-db5bb00021ef9137.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/student/department-info/page-f27317f75ec87cb1.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/student/enter-email/page-b3b9424966f8f96e.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/student/my-announcement-list/page-d27bd833002d3da0.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/student/my-announcement/%5BannouncementId%5D/page-588a8f1a8b4afd09.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/student/my-event-list/page-5cfd73face4f498c.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/student/reset-password/page-f19ca39c42c806de.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/app/student/sign-up/page-0ac5985d56f6568e.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/c16f53c3-f489ae0479dc8254.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/framework-c054b661e612b06c.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/main-7594b52b5f9609b2.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/main-app-5dede35926e7acd8.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/pages/_app-5d1abe03d322390c.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/pages/_error-3b2a1d523de49635.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/chunks/polyfills-42372ed130431b0a.js",revision:"846118c33b2c0e922d7b3a7676f81f6f"},{url:"/_next/static/chunks/webpack-e45c1e89b4cb0e39.js",revision:"Diyy8M36gApXRdKf3hm2c"},{url:"/_next/static/css/17f3245cf639fbc9.css",revision:"17f3245cf639fbc9"},{url:"/_next/static/css/22fb26c8aa024b54.css",revision:"22fb26c8aa024b54"},{url:"/_next/static/css/2a932fbdb5b09812.css",revision:"2a932fbdb5b09812"},{url:"/_next/static/css/7ccd9aa5c4bda771.css",revision:"7ccd9aa5c4bda771"},{url:"/_next/static/css/b61a5697f8be7fa2.css",revision:"b61a5697f8be7fa2"},{url:"/_next/static/css/b81626f4c8266e96.css",revision:"b81626f4c8266e96"},{url:"/_next/static/css/c476cfdfae100245.css",revision:"c476cfdfae100245"},{url:"/_next/static/css/c9fa9fcd1bb1214a.css",revision:"c9fa9fcd1bb1214a"},{url:"/_next/static/css/cee11ca9fce60a0f.css",revision:"cee11ca9fce60a0f"},{url:"/_next/static/media/logo.797040a0.svg",revision:"3eda663c6a66358d058ed6275015f8c0"},{url:"/_next/static/media/og_logo.35d22477.png",revision:"7db5ccb32ee9ae63b0493dd2f708c9d0"},{url:"/_next/static/media/white_logo.6ca09227.svg",revision:"f396d06ffdcd7c27d3e288635b4fd2f0"},{url:"/fonts/PretendardVariable.ttf",revision:"872a6c5775ec910058a9a409a201972a"},{url:"/fonts/chnam.ttf",revision:"fe9bf992e0acf8d7ad65ba9d521b8e68"},{url:"/icons/logo.svg",revision:"3eda663c6a66358d058ed6275015f8c0"},{url:"/icons/picture.svg",revision:"4216ece172b0ae9a28f5ff8a54c8b354"},{url:"/images/chnam_log_white.svg",revision:"b363fef28a0c98b35541d71fbefa0540"},{url:"/images/chnam_logo.svg",revision:"4a0e3a9497d8ea68991166d783727644"},{url:"/images/icon.png",revision:"2c685024cb11e7bc77ff819dbfbed2c3"},{url:"/images/logo.png",revision:"2c685024cb11e7bc77ff819dbfbed2c3"},{url:"/images/og_logo.png",revision:"7db5ccb32ee9ae63b0493dd2f708c9d0"},{url:"/images/white_logo.svg",revision:"f396d06ffdcd7c27d3e288635b4fd2f0"}],{ignoreURLParametersMatching:[/^utm_/,/^fbclid$/]}),e.cleanupOutdatedCaches(),e.registerRoute("/",new e.NetworkFirst({cacheName:"start-url",plugins:[{cacheWillUpdate:function(e){return _ref.apply(this,arguments)}}]}),"GET"),e.registerRoute(/^https:\/\/fonts\.(?:gstatic)\.com\/.*/i,new e.CacheFirst({cacheName:"google-fonts-webfonts",plugins:[new e.ExpirationPlugin({maxEntries:4,maxAgeSeconds:31536e3})]}),"GET"),e.registerRoute(/^https:\/\/fonts\.(?:googleapis)\.com\/.*/i,new e.StaleWhileRevalidate({cacheName:"google-fonts-stylesheets",plugins:[new e.ExpirationPlugin({maxEntries:4,maxAgeSeconds:604800})]}),"GET"),e.registerRoute(/\.(?:eot|otf|ttc|ttf|woff|woff2|font.css)$/i,new e.StaleWhileRevalidate({cacheName:"static-font-assets",plugins:[new e.ExpirationPlugin({maxEntries:4,maxAgeSeconds:604800})]}),"GET"),e.registerRoute(/\.(?:jpg|jpeg|gif|png|svg|ico|webp)$/i,new e.StaleWhileRevalidate({cacheName:"static-image-assets",plugins:[new e.ExpirationPlugin({maxEntries:64,maxAgeSeconds:2592e3})]}),"GET"),e.registerRoute(/\/_next\/static.+\.js$/i,new e.CacheFirst({cacheName:"next-static-js-assets",plugins:[new e.ExpirationPlugin({maxEntries:64,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(/\/_next\/image\?url=.+$/i,new e.StaleWhileRevalidate({cacheName:"next-image",plugins:[new e.ExpirationPlugin({maxEntries:64,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(/\.(?:mp3|wav|ogg)$/i,new e.CacheFirst({cacheName:"static-audio-assets",plugins:[new e.RangeRequestsPlugin,new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(/\.(?:mp4|webm)$/i,new e.CacheFirst({cacheName:"static-video-assets",plugins:[new e.RangeRequestsPlugin,new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(/\.(?:js)$/i,new e.StaleWhileRevalidate({cacheName:"static-js-assets",plugins:[new e.ExpirationPlugin({maxEntries:48,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(/\.(?:css|less)$/i,new e.StaleWhileRevalidate({cacheName:"static-style-assets",plugins:[new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(/\/_next\/data\/.+\/.+\.json$/i,new e.StaleWhileRevalidate({cacheName:"next-data",plugins:[new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(/\.(?:json|xml|csv)$/i,new e.NetworkFirst({cacheName:"static-data-assets",plugins:[new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(function(e){var s=e.sameOrigin,c=e.url.pathname;return!(!s||c.startsWith("/api/auth/callback")||!c.startsWith("/api/"))},new e.NetworkFirst({cacheName:"apis",networkTimeoutSeconds:10,plugins:[new e.ExpirationPlugin({maxEntries:16,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(function(e){var s=e.request,c=e.url.pathname,i=e.sameOrigin;return"1"===s.headers.get("RSC")&&"1"===s.headers.get("Next-Router-Prefetch")&&i&&!c.startsWith("/api/")},new e.NetworkFirst({cacheName:"pages-rsc-prefetch",plugins:[new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(function(e){var s=e.request,c=e.url.pathname,i=e.sameOrigin;return"1"===s.headers.get("RSC")&&i&&!c.startsWith("/api/")},new e.NetworkFirst({cacheName:"pages-rsc",plugins:[new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(function(e){var s=e.url.pathname;return e.sameOrigin&&!s.startsWith("/api/")},new e.NetworkFirst({cacheName:"pages",plugins:[new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(function(e){return!e.sameOrigin},new e.NetworkFirst({cacheName:"cross-origin",networkTimeoutSeconds:10,plugins:[new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:3600})]}),"GET")});
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// If the loader is already loaded, just stop.
+if (!self.define) {
+  let registry = {};
+
+  // Used for `eval` and `importScripts` where we can't get script URL by other means.
+  // In both cases, it's safe to use a global var because those functions are synchronous.
+  let nextDefineUri;
+
+  const singleRequire = (uri, parentUri) => {
+    uri = new URL(uri + ".js", parentUri).href;
+    return registry[uri] || (
+      
+        new Promise(resolve => {
+          if ("document" in self) {
+            const script = document.createElement("script");
+            script.src = uri;
+            script.onload = resolve;
+            document.head.appendChild(script);
+          } else {
+            nextDefineUri = uri;
+            importScripts(uri);
+            resolve();
+          }
+        })
+      
+      .then(() => {
+        let promise = registry[uri];
+        if (!promise) {
+          throw new Error(`Module ${uri} didn’t register its module`);
+        }
+        return promise;
+      })
+    );
+  };
+
+  self.define = (depsNames, factory) => {
+    const uri = nextDefineUri || ("document" in self ? document.currentScript.src : "") || location.href;
+    if (registry[uri]) {
+      // Module is already loading or loaded.
+      return;
+    }
+    let exports = {};
+    const require = depUri => singleRequire(depUri, uri);
+    const specialDeps = {
+      module: { uri },
+      exports,
+      require
+    };
+    registry[uri] = Promise.all(depsNames.map(
+      depName => specialDeps[depName] || require(depName)
+    )).then(deps => {
+      factory(...deps);
+      return exports;
+    });
+  };
+}
+define(['./workbox-7144475a'], (function (workbox) { 'use strict';
+
+  importScripts();
+  self.skipWaiting();
+  workbox.clientsClaim();
+  workbox.registerRoute("/", new workbox.NetworkFirst({
+    "cacheName": "start-url",
+    plugins: [{
+      cacheWillUpdate: function (_) {
+        return _ref.apply(this, arguments);
+      }
+    }]
+  }), 'GET');
+  workbox.registerRoute(/.*/i, new workbox.NetworkOnly({
+    "cacheName": "dev",
+    plugins: []
+  }), 'GET');
+
+}));

--- a/src/components/common/CommitteeHeader/index.module.scss
+++ b/src/components/common/CommitteeHeader/index.module.scss
@@ -14,6 +14,7 @@
   border-bottom: 0.1rem solid black;
   padding: 4rem 5rem;
   position: relative;
+  height: 15rem;
 }
 
 .logo {

--- a/src/components/common/CommitteeHeader/index.tsx
+++ b/src/components/common/CommitteeHeader/index.tsx
@@ -26,7 +26,7 @@ export default function CommitteeHeader() {
     <>
       <header className={cn("header")}>
         <Link href={ROUTE.COMMITTEE.APPLY_LIST} className={cn("logo")}>
-          <Logo width={100} height={40} />
+          <Logo width={100} height={50} />
           <Txt fontType="chnam" className={cn("headerTitle")}>
             전남대학교 사물함 신청 서비스
           </Txt>

--- a/src/components/page/committee/event-list/index.module.scss
+++ b/src/components/page/committee/event-list/index.module.scss
@@ -49,10 +49,64 @@
   }
 }
 
-.publish {
+.toggleCell {
+  @include flexSort(row, center, center, null);
+}
+
+.toggleContainer {
   @include flexSort(row, center, center, 1rem);
 }
 
-.btn {
-  padding: 1rem 1.5rem;
+.toggleLabel {
+  min-width: 5rem;
+}
+
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 5rem;
+  height: 2.4rem;
+  cursor: pointer;
+}
+
+.toggleInput {
+  opacity: 0;
+  width: 0;
+  height: 0;
+
+  &:checked + .toggleSlider {
+    background-color: $primary; // 활성화 시 primary 컬러
+  }
+
+  &:checked + .toggleSlider:before {
+    transform: translateX(2.6rem); // 슬라이더 이동
+  }
+
+  &:disabled + .toggleSlider {
+    opacity: 0.5; // 비활성화 시 투명도 적용
+    cursor: not-allowed;
+  }
+}
+
+.toggleSlider {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc; // 기본 회색 배경
+  border-radius: 3.4rem;
+  transition: all 0.3s ease; // 부드러운 애니메이션
+
+  &:before {
+    position: absolute;
+    content: "";
+    height: 1.8rem;
+    width: 1.8rem;
+    left: 0.3rem;
+    bottom: 0.3rem;
+    background-color: white;
+    border-radius: 50%;
+    transition: transform 0.3s ease; // 슬라이더 이동 애니메이션
+  }
 }

--- a/src/components/page/committee/event-list/index.tsx
+++ b/src/components/page/committee/event-list/index.tsx
@@ -3,7 +3,6 @@
 import classNames from "classnames/bind";
 import styles from "./index.module.scss";
 import Txt from "@/components/design-system/Txt";
-import Button from "@/components/design-system/Button";
 import { useEventList } from "@/hooks/committee/event/useEventList";
 import Pagination from "@/components/common/Pagination";
 import { formatToKoreanTime } from "@/utils/date";
@@ -64,17 +63,12 @@ export default function EventList() {
                   게시 상태
                 </Txt>
               </th>
-              <th className={cn("tableHeader")}>
-                <Txt color="white" weight="medium">
-                  게시
-                </Txt>
-              </th>
             </tr>
           </thead>
           <tbody>
             {isLoading ? (
               <tr>
-                <td colSpan={6}>
+                <td colSpan={5}>
                   <Skeleton className={cn("skeleton")} />
                 </td>
               </tr>
@@ -90,34 +84,25 @@ export default function EventList() {
                   <td className={cn("tableData")}>
                     <Txt size="h6">{event.status}</Txt>
                   </td>
-                  <td className={cn("tableData")}>
-                    <Txt size="h6">{event.publish === true ? "공개" : "비공개"}</Txt>
-                  </td>
-                  <td className={cn("tableData", "publish")}>
-                    <Button
-                      color="primary"
-                      className={cn("btn")}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onChangeEventPublish(event.id, true);
-                      }}
-                      disabled={isChangeEventLoading}
-                    >
-                      <Txt color="white" size="h6">
-                        공개
-                      </Txt>
-                    </Button>
-                    <Button
-                      color="gray"
-                      className={cn("btn")}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onChangeEventPublish(event.id, false);
-                      }}
-                      disabled={isChangeEventLoading}
-                    >
-                      <Txt size="h6">비공개</Txt>
-                    </Button>
+                  <td className={cn("tableData", "toggleCell")} onClick={(e) => e.stopPropagation()}>
+                    <div className={cn("toggleContainer")}>
+                      <span className={cn("toggleLabel")}>
+                        <Txt size="h6">{event.publish ? "공개" : "비공개"}</Txt>
+                      </span>
+                      <label className={cn("toggle")}>
+                        <input
+                          type="checkbox"
+                          checked={event.publish}
+                          onChange={(e) => {
+                            e.stopPropagation();
+                            onChangeEventPublish(event.id, e.target.checked);
+                          }}
+                          disabled={isChangeEventLoading}
+                          className={cn("toggleInput")}
+                        />
+                        <span className={cn("toggleSlider")}></span>
+                      </label>
+                    </div>
                   </td>
                 </tr>
               ))


### PR DESCRIPTION
### 개요

close #144 

### 작업사항

- 이벤트 게시 상태 변경 UI를 버튼에서 토글로 변경하였습니다.

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이벤트 목록에서 공개 상태를 토글할 수 있는 스위치 UI가 추가되었습니다.

* **스타일**
  * CommitteeHeader 컴포넌트의 헤더 높이가 15rem으로 고정되었습니다.
  * CommitteeHeader의 로고 높이가 50으로 조정되었습니다.
  * 이벤트 목록의 공개 상태 토글 UI가 새롭게 디자인되었으며, 토글 스위치 스타일이 적용되었습니다.

* **리팩터**
  * 이벤트 목록에서 공개 상태 변경 버튼이 토글 스위치로 통합되어 더 직관적으로 변경되었습니다.

* **기타**
  * 서비스 워커가 간소화되어 불필요한 캐싱 및 라우트 등록이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->