### PR TITLE
refactor: access token 중복 갱신 요청 문제 해결

### DIFF
--- a/src/apis/instance/https.ts
+++ b/src/apis/instance/https.ts
@@ -1,8 +1,6 @@
-import axios, { AxiosRequestConfig, AxiosResponse, AxiosError } from "axios";
-import { postReissue } from "@/apis/common/token";
-import { baseInstance } from "./baseInstance";
-
-const RETRY_HEADER_KEY = "retry";
+import axios, { AxiosResponse, AxiosError } from "axios";
+import { canRetryRequest, getIsRefreshing, isTokenError, processQueue, refreshAccessToken, setIsRefreshing } from "@/functions/axios";
+import { REQUEST_QUEUE, RETRY_HEADER_KEY } from "@/constants/axios";
 
 export const https = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_BASE_URL}v1/`,
@@ -19,56 +17,6 @@ https.interceptors.request.use((config) => {
   return config;
 });
 
-interface QueuedRequest {
-  resolve: (value: AxiosResponse) => void;
-  reject: (reason: Error) => void;
-  config: AxiosRequestConfig;
-}
-
-const requestQueue: QueuedRequest[] = [];
-
-let isRefreshing = false;
-
-const isTokenError = (error: AxiosError): boolean => {
-  return error.response?.status === 401;
-};
-
-const canRetryRequest = (config: AxiosRequestConfig | undefined): boolean => {
-  return config !== undefined && !config.headers?.[RETRY_HEADER_KEY];
-};
-
-const refreshAccessToken = async (): Promise<string> => {
-  const result = await postReissue();
-  if (!result) {
-    throw new Error("토큰 갱신에 실패했습니다.");
-  }
-  return result.accessToken;
-};
-
-const processQueue = (error: Error | null, token: string | null = null): void => {
-  requestQueue.forEach(({ resolve, reject, config }) => {
-    if (error) {
-      reject(error);
-      return;
-    }
-    if (token) {
-      const configCopy: AxiosRequestConfig = {
-        ...config,
-        headers: {
-          ...config.headers,
-          Authorization: `Bearer ${token}`,
-        },
-      };
-      if (configCopy.headers) {
-        delete configCopy.headers[RETRY_HEADER_KEY];
-      }
-      baseInstance(configCopy).then(resolve).catch(reject);
-    }
-  });
-  requestQueue.length = 0;
-  isRefreshing = false;
-};
-
 https.interceptors.response.use(
   (response: AxiosResponse) => response,
   async (error: AxiosError) => {
@@ -82,13 +30,13 @@ https.interceptors.response.use(
     }
 
     return new Promise<AxiosResponse>((resolve, reject) => {
-      requestQueue.push({ resolve, reject, config: originalRequest! });
+      REQUEST_QUEUE.push({ resolve, reject, config: originalRequest! });
 
-      if (isRefreshing) {
+      if (getIsRefreshing()) {
         return;
       }
 
-      isRefreshing = true;
+      setIsRefreshing(true);
 
       refreshAccessToken()
         .then((newAccessToken) => {

--- a/src/apis/instance/https.ts
+++ b/src/apis/instance/https.ts
@@ -1,6 +1,8 @@
-import axios from "axios";
+import axios, { AxiosRequestConfig, AxiosResponse, AxiosError } from "axios";
 import { postReissue } from "@/apis/common/token";
 import { baseInstance } from "./baseInstance";
+// 재시도 헤더 키 상수
+const RETRY_HEADER_KEY = "retry";
 
 export const https = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_BASE_URL}v1/`,
@@ -11,28 +13,91 @@ export const https = axios.create({
 
 https.interceptors.request.use((config) => {
   const accessToken = typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
-
   if (accessToken) {
     config.headers.Authorization = `Bearer ${accessToken}`;
   }
   return config;
 });
 
-https.interceptors.response.use(
-  (response) => {
-    return response;
-  },
-  async (error) => {
-    const originalRequest = error.config;
+interface QueuedRequest {
+  resolve: (value: AxiosResponse) => void;
+  reject: (reason: Error) => void;
+  config: AxiosRequestConfig;
+}
 
-    if (error.response?.status === 401) {
-      const result = await postReissue();
+const requestQueue: QueuedRequest[] = [];
 
-      if (result) {
-        return baseInstance(originalRequest);
+let isRefreshing = false;
+
+const isTokenError = (error: AxiosError): boolean => {
+  return error.response?.status === 401;
+};
+
+const canRetryRequest = (config: AxiosRequestConfig | undefined): boolean => {
+  return config !== undefined && !config.headers?.[RETRY_HEADER_KEY];
+};
+
+const refreshAccessToken = async (): Promise<string> => {
+  const result = await postReissue();
+  if (!result) {
+    throw new Error("토큰 갱신에 실패했습니다.");
+  }
+  return result.accessToken;
+};
+
+const processQueue = (error: Error | null, token: string | null = null): void => {
+  requestQueue.forEach(({ resolve, reject, config }) => {
+    if (error) {
+      reject(error);
+      return;
+    }
+    if (token) {
+      const configCopy: AxiosRequestConfig = {
+        ...config,
+        headers: {
+          ...config.headers,
+          Authorization: `Bearer ${token}`,
+        },
+      };
+      if (configCopy.headers) {
+        delete configCopy.headers[RETRY_HEADER_KEY];
       }
+      baseInstance(configCopy).then(resolve).catch(reject);
+    }
+  });
+  requestQueue.length = 0;
+  isRefreshing = false;
+};
+
+https.interceptors.response.use(
+  (response: AxiosResponse) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config;
+    if (!isTokenError(error) || !canRetryRequest(originalRequest)) {
+      return Promise.reject(error);
     }
 
-    return Promise.reject(error);
+    if (originalRequest?.headers) {
+      originalRequest.headers[RETRY_HEADER_KEY] = true;
+    }
+
+    return new Promise<AxiosResponse>((resolve, reject) => {
+      requestQueue.push({ resolve, reject, config: originalRequest! });
+
+      if (isRefreshing) {
+        return;
+      }
+
+      isRefreshing = true;
+
+      // 토큰 갱신 시도
+      refreshAccessToken()
+        .then((newAccessToken) => {
+          processQueue(null, newAccessToken);
+        })
+        .catch((refreshError) => {
+          processQueue(refreshError, null);
+        });
+    });
   },
 );

--- a/src/apis/instance/https.ts
+++ b/src/apis/instance/https.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosRequestConfig, AxiosResponse, AxiosError } from "axios";
 import { postReissue } from "@/apis/common/token";
 import { baseInstance } from "./baseInstance";
-// 재시도 헤더 키 상수
+
 const RETRY_HEADER_KEY = "retry";
 
 export const https = axios.create({
@@ -90,7 +90,6 @@ https.interceptors.response.use(
 
       isRefreshing = true;
 
-      // 토큰 갱신 시도
       refreshAccessToken()
         .then((newAccessToken) => {
           processQueue(null, newAccessToken);

--- a/src/constants/axios/index.ts
+++ b/src/constants/axios/index.ts
@@ -1,0 +1,11 @@
+import { AxiosRequestConfig, AxiosResponse } from "axios";
+
+export const RETRY_HEADER_KEY = "_retry";
+
+interface QueuedRequest {
+  resolve: (value: AxiosResponse) => void;
+  reject: (reason: Error) => void;
+  config: AxiosRequestConfig;
+}
+
+export const REQUEST_QUEUE: QueuedRequest[] = [];

--- a/src/functions/axios/index.ts
+++ b/src/functions/axios/index.ts
@@ -1,0 +1,53 @@
+import { postReissue } from "@/apis/common/token";
+import { baseInstance } from "@/apis/instance/baseInstance";
+import {  REQUEST_QUEUE, RETRY_HEADER_KEY } from "@/constants/axios";
+import { AxiosError, AxiosRequestConfig } from "axios";
+
+export const isTokenError = (error: AxiosError): boolean => {
+  return error.response?.status === 401;
+};
+
+export const canRetryRequest = (config: AxiosRequestConfig | undefined): boolean => {
+  return config !== undefined && !config.headers?.[RETRY_HEADER_KEY];
+};
+
+export const refreshAccessToken = async (): Promise<string> => {
+  const result = await postReissue();
+  if (!result) {
+    throw new Error("토큰 갱신에 실패했습니다.");
+  }
+  return result.accessToken;
+};
+
+let IS_REFRESHING = false;
+
+
+export const getIsRefreshing = () => IS_REFRESHING;
+
+export const setIsRefreshing = (value: boolean) => {
+  IS_REFRESHING = value;
+};
+
+export const processQueue = (error: Error | null, token: string | null = null): void => {
+  REQUEST_QUEUE.forEach(({ resolve, reject, config }) => {
+    if (error) {
+      reject(error);
+      return;
+    }
+    if (token) {
+      const configCopy: AxiosRequestConfig = {
+        ...config,
+        headers: {
+          ...config.headers,
+          Authorization: `Bearer ${token}`,
+        },
+      };
+      if (configCopy.headers) {
+        delete configCopy.headers[RETRY_HEADER_KEY];
+      }
+      baseInstance(configCopy).then(resolve).catch(reject);
+    }
+  });
+  REQUEST_QUEUE.length = 0;
+  setIsRefreshing(false);
+};


### PR DESCRIPTION
### 개요

close #191 

### 작업사항

동시에 발생하는 API의 인증 에러에 대해 access token 갱신 로직이 중복 실행되는 문제를 해결하기 위해 Queue와 이벤트 루프를 활용하여 문제를 해결하였습니다.

### 체크리스트

- [x] assignees 설정
- [x] label 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 버그 수정
  * 401 응답 처리에서 액세스 토큰 자동 갱신을 안정화하여 한 번에 하나의 갱신만 수행하도록 했습니다.
  * 갱신 중인 요청들은 큐에 보관한 뒤 갱신 성공 시 새 토큰으로 자동 재시도합니다.
  * 무한 재시도 루프를 방지하고, 갱신 실패 시 보류 요청에 적절히 오류를 반환합니다.
  * 일시적 인증 만료로 인한 요청 실패와 반복 요청 문제를 줄여 세션 신뢰성을 향상했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->